### PR TITLE
minor fixes (initiated by some reportes issues)

### DIFF
--- a/scintilla/deelx/DeelxRegexSearch.cxx
+++ b/scintilla/deelx/DeelxRegexSearch.cxx
@@ -154,8 +154,9 @@ long DeelxRegexSearch::FindText(Document* doc, int minPos, int maxPos, const cha
     startPos = doc->MovePositionOutsideChar(startPos, 1, false);
     endPos = doc->MovePositionOutsideChar(endPos, 1, false);
 
-    int compileFlags(deelx::MULTILINE | deelx::GLOBAL | deelx::EXTENDED); // the .(dot) does not match line-breaks
-    //int compileFlags(deelx::SINGLELINE | deelx::MULTILINE | deelx::GLOBAL | deelx::EXTENDED);  // the .(dot) also matches line-breaks
+    //int compileFlags(deelx::SINGLELINE | deelx::MULTILINE | deelx::GLOBAL);  // the .(dot) also matches line-breaks
+    int compileFlags(deelx::MULTILINE | deelx::GLOBAL); // the .(dot) does not match line-breaks
+    //compileFlags |= deelx::EXTENDED; // ignore spaces and use '#' as line-comment)
     compileFlags |= (caseSensitive) ? deelx::NO_FLAG : deelx::IGNORECASE;
     compileFlags |= (left2right) ? deelx::NO_FLAG : deelx::RIGHTTOLEFT;
 

--- a/src/Helpers.c
+++ b/src/Helpers.c
@@ -93,6 +93,34 @@ int IniSectionGetInt(
 }
 
 
+UINT IniSectionGetUInt(
+    LPCWSTR lpCachedIniSection,
+    LPCWSTR lpName,
+    UINT uDefault) {
+    WCHAR *p = (WCHAR *)lpCachedIniSection;
+    WCHAR tch[256];
+    int  ich;
+    UINT u;
+
+    if (p) {
+        lstrcpy(tch, lpName);
+        lstrcat(tch, L"=");
+        ich = lstrlen(tch);
+
+        while (*p) {
+            if (StrCmpNI(p, tch, ich) == 0) {
+                if (swscanf_s(p + ich, L"%u", &u) == 1)
+                    return(u);
+                else
+                    return(uDefault);
+            }
+            else
+                p = StrEnd(p) + 1;
+        }
+    }
+    return(uDefault);
+}
+
 BOOL IniSectionSetString(LPWSTR lpCachedIniSection,LPCWSTR lpName,LPCWSTR lpString)
 {
   WCHAR tch[32+512*3+32];

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -41,6 +41,7 @@ __inline BOOL IniSetInt(LPCWSTR lpSection,LPCWSTR lpName,int i) {
   WritePrivateProfileSection(lpSection,lpBuf,szIniFile)
 int IniSectionGetString(LPCWSTR,LPCWSTR,LPCWSTR,LPWSTR,int);
 int IniSectionGetInt(LPCWSTR,LPCWSTR,int);
+UINT IniSectionGetUInt(LPCWSTR,LPCWSTR,UINT);
 BOOL IniSectionSetString(LPWSTR,LPCWSTR,LPCWSTR);
 __inline BOOL IniSectionSetInt(LPWSTR lpCachedIniSection,LPCWSTR lpName,int i) {
   WCHAR tch[32]; wsprintf(tch,L"%i",i); return IniSectionSetString(lpCachedIniSection,lpName,tch);

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -5669,9 +5669,9 @@ void LoadSettings()
   bViewEOLs = IniSectionGetInt(pIniSection,L"ViewEOLs",0);
   if (bViewEOLs) bViewEOLs = 1;
 
-  iDefaultEncoding = IniSectionGetInt(pIniSection,L"DefaultEncoding",0);
+  iDefaultEncoding = IniSectionGetInt(pIniSection,L"DefaultEncoding", (int)GetACP());
   iDefaultEncoding = Encoding_MapIniSetting(TRUE,iDefaultEncoding);
-  if (!Encoding_IsValid(iDefaultEncoding)) iDefaultEncoding = CPI_UTF8;
+  if (!Encoding_IsValid(iDefaultEncoding)) iDefaultEncoding = CPI_DEFAULT;
 
   bSkipUnicodeDetection = IniSectionGetInt(pIniSection,L"SkipUnicodeDetection",0);
   if (bSkipUnicodeDetection) bSkipUnicodeDetection = 1;
@@ -5837,18 +5837,26 @@ void LoadSettings()
 
   LocalFree(pIniSection);
 
-  iDefaultCodePage = 0; {
+  /*
+  iDefaultCodePage = CPI_DEFAULT;
+  {
+    // check for Chinese, Japan, Korean CPs
     int acp = GetACP();
     if (acp == 932 || acp == 936 || acp == 949 || acp == 950 || acp == 1361)
-      iDefaultCodePage = acp;
+      iDefaultCodePage = Encoding_MapIniSetting(TRUE, acp);
   }
+  */
+
+  // sync Encoding and CodePage
+  iDefaultCodePage = iDefaultEncoding;
+
 
   {
     CHARSETINFO ci;
-    if (TranslateCharsetInfo((DWORD*)(UINT_PTR)iDefaultCodePage,&ci,TCI_SRCCODEPAGE))
-      iDefaultCharSet = ci.ciCharset;
+    if (TranslateCharsetInfo((DWORD*)(UINT_PTR)iDefaultCodePage, &ci, TCI_SRCCODEPAGE))
+        iDefaultCharSet = ci.ciCharset;
     else
-      iDefaultCharSet = ANSI_CHARSET;
+        iDefaultCharSet = DEFAULT_CHARSET; // ANSI_CHARSET;
   }
 
   // Scintilla Styles


### PR DESCRIPTION
- fixed: broken Ctrl-Q (toggle line comments)
- remember more settings/checksboxes for “Find text” dialog between sessions (.ini-file persistence of (open) dialog)
- DeelX RegexSearch:  remove EXTENDED mode - that disables white space ignore and '#' as line comment (expexted/convenient behaviour)
   -- that fixes also the "Alt-W" (remove trailing spaces) issue on selection only
- fixing ".LOG-feature" of Notepad : ".LOG" recognition must be case sensitive