### PR TITLE
fixes crash in Favorites Management

### DIFF
--- a/src/Helpers.c
+++ b/src/Helpers.c
@@ -1036,6 +1036,26 @@ int FormatString(LPWSTR lpOutput,int nOutput,UINT uIdFormat,...)
 
 //=============================================================================
 //
+//  GetKnownFolderPath()
+//
+BOOL GetKnownFolderPath(REFKNOWNFOLDERID rfid, LPWSTR lpOutPath, size_t cchCount)
+{
+  //const DWORD dwFlags = (KF_FLAG_DEFAULT_PATH | KF_FLAG_NOT_PARENT_RELATIVE | KF_FLAG_NO_ALIAS);
+  const DWORD dwFlags = KF_FLAG_NO_ALIAS;
+
+  PWSTR pszPath = NULL;
+  HRESULT hr = SHGetKnownFolderPath(rfid, dwFlags, NULL, &pszPath);
+  if (SUCCEEDED(hr) && pszPath) {
+    StringCchCopy(lpOutPath, cchCount, pszPath);
+    CoTaskMemFree(pszPath);
+    return TRUE;
+  }
+  return FALSE;
+}
+
+
+//=============================================================================
+//
 //  PathRelativeToApp()
 //
 void PathRelativeToApp(
@@ -1053,7 +1073,8 @@ void PathRelativeToApp(
   PathCanonicalizeEx(wchAppPath,MAX_PATH);
   PathCchRemoveFileSpec(wchAppPath,COUNTOF(wchAppPath));
   GetWindowsDirectory(wchWinDir,COUNTOF(wchWinDir));
-  SHGetFolderPath(NULL,CSIDL_PERSONAL,NULL,SHGFP_TYPE_CURRENT,wchUserFiles);
+  //SHGetFolderPath(NULL,CSIDL_PERSONAL,NULL,SHGFP_TYPE_CURRENT,wchUserFiles);
+  GetKnownFolderPath(&FOLDERID_Documents, wchUserFiles, COUNTOF(wchUserFiles));
 
   if (bUnexpandMyDocs &&
       !PathIsRelative(lpszSrc) &&
@@ -1101,7 +1122,8 @@ void PathAbsoluteFromApp(LPWSTR lpszSrc,LPWSTR lpszDest,int cchDest,BOOL bExpand
   }
 
   if (StrCmpNI(lpszSrc,L"%CSIDL:MYDOCUMENTS%",CSTRLEN("%CSIDL:MYDOCUMENTS%")) == 0) {
-    SHGetFolderPath(NULL,CSIDL_PERSONAL,NULL,SHGFP_TYPE_CURRENT,wchPath);
+    //SHGetFolderPath(NULL,CSIDL_PERSONAL,NULL,SHGFP_TYPE_CURRENT,wchPath);
+    GetKnownFolderPath(&FOLDERID_Documents, wchPath, COUNTOF(wchPath));
     PathCchAppend(wchPath,COUNTOF(wchPath),lpszSrc+CSTRLEN("%CSIDL:MYDOCUMENTS%"));
   }
   else {
@@ -1283,7 +1305,8 @@ BOOL PathCreateDeskLnk(LPCWSTR pszDocument)
   StringCchCopy(tchArguments,COUNTOF(tchArguments),L"-n ");
   StringCchCat(tchArguments,COUNTOF(tchArguments),tchDocTemp);
 
-  SHGetSpecialFolderPath(NULL,tchLinkDir,CSIDL_DESKTOPDIRECTORY,TRUE);
+  //SHGetSpecialFolderPath(NULL,tchLinkDir,CSIDL_DESKTOPDIRECTORY,TRUE);
+  GetKnownFolderPath(&FOLDERID_Desktop, tchLinkDir, COUNTOF(tchLinkDir));
 
   GetString(IDS_LINKDESCRIPTION,tchDescription,COUNTOF(tchDescription));
 

--- a/src/Helpers.c
+++ b/src/Helpers.c
@@ -608,6 +608,7 @@ void CenterDlgInParent(HWND hDlg)
 
   SetWindowPos(hDlg,NULL,max(xMin,min(xMax,x)),max(yMin,min(yMax,y)),0,0,SWP_NOZORDER|SWP_NOSIZE);
 
+  //SnapToDefaultButton(hDlg);
 }
 
 
@@ -671,6 +672,41 @@ void SetDlgPos(HWND hDlg,int xDlg,int yDlg)
   SetWindowPos(hDlg,NULL,max(xMin,min(xMax,x)),max(yMin,min(yMax,y)),0,0,SWP_NOZORDER|SWP_NOSIZE);
 
 }
+
+/*
+
+ ... only if we are working with nonstandard dialog boxes ...
+
+//=============================================================================
+//
+//  SnapToDefaultButton()
+//
+// Why doesn't the "Automatically move pointer to the default button in a dialog box"
+// work for nonstandard dialog boxes, and how do I add it to my own nonstandard dialog boxes?
+// https://blogs.msdn.microsoft.com/oldnewthing/20130826-00/?p=3413/
+//
+void SnapToDefaultButton(HWND hwndBox)
+{
+  BOOL bSnapToDefButton = FALSE;
+  if (SystemParametersInfo(SPI_GETSNAPTODEFBUTTON, 0, &bSnapToDefButton, 0) && bSnapToDefButton) {
+    // get child window at the top of the Z order.
+    // for all our MessageBoxs it's the OK or YES button or NULL.
+    HWND btn = GetWindow(hwndBox, GW_CHILD);
+    if (btn != NULL) {
+      WCHAR className[32] = L"";
+      GetClassName(btn, className, COUNTOF(className));
+      if (lstrcmpi(className, L"Button") == 0) {
+        RECT rect;
+        int x, y;
+        GetWindowRect(btn, &rect);
+        x = rect.left + (rect.right - rect.left) / 2;
+        y = rect.top + (rect.bottom - rect.top) / 2;
+        SetCursorPos(x, y);
+      }
+    }
+  }
+}
+*/
 
 
 //=============================================================================

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -125,6 +125,7 @@ void SetWindowTransparentMode(HWND,BOOL);
 void CenterDlgInParent(HWND);
 void GetDlgPos(HWND,LPINT,LPINT);
 void SetDlgPos(HWND,int,int);
+//void SnapToDefaultButton(HWND);
 void ResizeDlg_Init(HWND,int,int,int);
 void ResizeDlg_Destroy(HWND,int*,int*);
 void ResizeDlg_Size(HWND,LPARAM,int*,int*);

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -159,7 +159,7 @@ BOOL IsCmdEnabled(HWND, UINT);
 
 int FormatString(LPWSTR,int,UINT,...);
 
-
+BOOL GetKnownFolderPath(REFKNOWNFOLDERID, LPWSTR, size_t);
 void PathRelativeToApp(LPWSTR,LPWSTR,int,BOOL,BOOL,BOOL);
 void PathAbsoluteFromApp(LPWSTR,LPWSTR,int,BOOL);
 

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -2601,7 +2601,6 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
         sei.lpParameters = tchParam;
         sei.lpDirectory = NULL;
         sei.nShow = SW_SHOWNORMAL;
-        CoInitializeEx(NULL,COINIT_APARTMENTTHREADED | COINIT_SPEED_OVER_MEMORY);
         ShellExecuteEx(&sei);
 
         if ((INT_PTR)sei.hInstApp < 32)
@@ -2672,7 +2671,6 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
         sei.lpParameters = szParameters;
         sei.lpDirectory = g_wchWorkingDirectory;
         sei.nShow = SW_SHOWNORMAL;
-        CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_SPEED_OVER_MEMORY);
         ShellExecuteEx(&sei);
       }
       break;
@@ -2703,7 +2701,6 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
         sei.lpParameters = NULL;
         sei.lpDirectory = wchDirectory;
         sei.nShow = SW_SHOWNORMAL;
-        CoInitializeEx(NULL,COINIT_APARTMENTTHREADED | COINIT_SPEED_OVER_MEMORY);
         ShellExecuteEx(&sei);
       }
       break;
@@ -2772,7 +2769,6 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
         sei.lpVerb = L"properties";
         sei.lpFile = szCurFile;
         sei.nShow = SW_SHOWNORMAL;
-        CoInitializeEx(NULL,COINIT_APARTMENTTHREADED | COINIT_SPEED_OVER_MEMORY);
         ShellExecuteEx(&sei);
       }
       break;
@@ -2834,7 +2830,6 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
         sei.lpDirectory = NULL;
         sei.nShow = SW_SHOWNORMAL;
         // Run favorites directory
-        CoInitializeEx(NULL,COINIT_APARTMENTTHREADED | COINIT_SPEED_OVER_MEMORY);
         ShellExecuteEx(&sei);
       }
       break;
@@ -4938,7 +4933,6 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
               sei.lpParameters = lpszArgs;
               sei.lpDirectory = wchDirectory;
               sei.nShow = SW_SHOWNORMAL;
-              CoInitializeEx(NULL,COINIT_APARTMENTTHREADED | COINIT_SPEED_OVER_MEMORY);
               ShellExecuteEx(&sei);
 
               GlobalFree(lpszCommand);
@@ -5816,17 +5810,20 @@ void LoadSettings()
 
   efrData.fuFlags = IniSectionGetUInt(pIniSection, L"efrData_fuFlags", 0);
 
-  if (!IniSectionGetString(pIniSection,L"OpenWithDir",L"",
-        tchOpenWithDir,COUNTOF(tchOpenWithDir)))
-    SHGetSpecialFolderPath(NULL,tchOpenWithDir,CSIDL_DESKTOPDIRECTORY,TRUE);
-  else
-    PathAbsoluteFromApp(tchOpenWithDir,NULL,COUNTOF(tchOpenWithDir),TRUE);
-
-  if (!IniSectionGetString(pIniSection,L"Favorites",L"",
-        tchFavoritesDir,COUNTOF(tchFavoritesDir)))
-    SHGetFolderPath(NULL,CSIDL_PERSONAL,NULL,SHGFP_TYPE_CURRENT,tchFavoritesDir);
-  else
-    PathAbsoluteFromApp(tchFavoritesDir,NULL,COUNTOF(tchFavoritesDir),TRUE);
+  if (!IniSectionGetString(pIniSection, L"OpenWithDir", L"", tchOpenWithDir, COUNTOF(tchOpenWithDir))) {
+    //SHGetSpecialFolderPath(NULL, tchOpenWithDir, CSIDL_DESKTOPDIRECTORY, TRUE);
+    GetKnownFolderPath(&FOLDERID_Desktop, tchOpenWithDir, COUNTOF(tchOpenWithDir));
+  }
+  else {
+    PathAbsoluteFromApp(tchOpenWithDir, NULL, COUNTOF(tchOpenWithDir), TRUE);
+  }
+  if (!IniSectionGetString(pIniSection, L"Favorites", L"", tchFavoritesDir, COUNTOF(tchFavoritesDir))) {
+    //SHGetFolderPath(NULL,CSIDL_PERSONAL,NULL,SHGFP_TYPE_CURRENT,tchFavoritesDir);
+    GetKnownFolderPath(&FOLDERID_Favorites, tchFavoritesDir, COUNTOF(tchFavoritesDir));
+  }
+  else {
+    PathAbsoluteFromApp(tchFavoritesDir, NULL, COUNTOF(tchFavoritesDir), TRUE);
+  }
 
   iPathNameFormat = IniSectionGetInt(pIniSection,L"PathNameFormat",0);
   iPathNameFormat = max(min(iPathNameFormat,2),0);
@@ -6767,7 +6764,8 @@ int CheckIniFile(LPWSTR lpszFile,LPCWSTR lpszModule)
       return(1);
     }
     // %appdata%
-    if (S_OK == SHGetFolderPath(NULL,CSIDL_APPDATA,NULL,SHGFP_TYPE_CURRENT,tchBuild)) {
+    //if (S_OK == SHGetFolderPath(NULL, CSIDL_APPDATA, NULL, SHGFP_TYPE_CURRENT, tchBuild)) {
+    if (GetKnownFolderPath(&FOLDERID_RoamingAppData, tchBuild, COUNTOF(tchBuild))) {
       PathCchAppend(tchBuild,COUNTOF(tchBuild),tchFileExpanded);
       if (PathFileExists(tchBuild)) {
         StringCchCopy(lpszFile,MAX_PATH,tchBuild);
@@ -8312,7 +8310,6 @@ BOOL RelaunchElevated(LPWSTR lpArgs) {
     sei.lpParameters = szArguments;
     sei.lpDirectory = g_wchWorkingDirectory;
     sei.nShow = si.wShowWindow ? si.wShowWindow : SW_SHOWNORMAL;
-    CoInitializeEx(NULL,COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE | COINIT_SPEED_OVER_MEMORY);
     result = ShellExecuteEx(&sei);
   }
 


### PR DESCRIPTION
+ fix: crash in Favorites management 
   (release version only, debug version didn't crash - so hard to find)
+ small code refactoring (replacing deprecated methods)

Addressed issue (?):  reported at:
https://www.rizonesoft.com/downloads/notepad3/#comment-39463
