### PR TITLE
fixing replacement issue in case of active "Check All Occ" feature

### DIFF
--- a/src/Edit.h
+++ b/src/Edit.h
@@ -99,7 +99,6 @@ void  EditFixPositions(HWND);
 void  EditEnsureSelectionVisible(HWND);
 void  EditGetExcerpt(HWND,LPWSTR,DWORD);
 
-BOOL  EditFindHasMatch(HWND,LPCEDITFINDREPLACE,BOOL);
 HWND  EditFindReplaceDlg(HWND,LPCEDITFINDREPLACE,BOOL);
 BOOL  EditFindNext(HWND,LPCEDITFINDREPLACE,BOOL);
 BOOL  EditFindPrev(HWND,LPCEDITFINDREPLACE,BOOL);


### PR DESCRIPTION
+ fix: issue #173 - regex/wildcard search: replacement string not used if "Check All Occurrences" is active