### PR TITLE
Reverting default for Scintilla's DirectWrite technology

### DIFF
--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -645,6 +645,7 @@ int WINAPI WinMain(HINSTANCE hInstance,HINSTANCE hPrevInst,LPSTR lpCmdLine,int n
     return FALSE;
   
   if (IsVista()) {
+    SciCall_UnBufferedDraw();
     if (iSciDirectWriteTech >= 0)
       SciCall_SetTechnology(DirectWriteTechnology[iSciDirectWriteTech]);
   }
@@ -5875,7 +5876,7 @@ void LoadSettings()
   dwFileCheckInverval = IniSectionGetInt(pIniSection,L"FileCheckInverval",2000);
   dwAutoReloadTimeout = IniSectionGetInt(pIniSection,L"AutoReloadTimeout",2000);
 
-  iSciDirectWriteTech = IniSectionGetInt(pIniSection,L"SciDirectWriteTech",1);
+  iSciDirectWriteTech = IniSectionGetInt(pIniSection,L"SciDirectWriteTech",0);
   iSciDirectWriteTech = max(min(iSciDirectWriteTech,3),-1);
 
   iSciFontQuality = IniSectionGetInt(pIniSection,L"SciFontQuality",3);

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -645,7 +645,7 @@ int WINAPI WinMain(HINSTANCE hInstance,HINSTANCE hPrevInst,LPSTR lpCmdLine,int n
     return FALSE;
   
   if (IsVista()) {
-    SciCall_UnBufferedDraw();
+    SciCall_UnBufferedDraw();  // Current platforms perform window buffering so it is almost always better for this option to be turned off.
     if (iSciDirectWriteTech >= 0)
       SciCall_SetTechnology(DirectWriteTechnology[iSciDirectWriteTech]);
   }
@@ -5869,11 +5869,11 @@ void LoadSettings()
   dwFileCheckInverval = IniSectionGetInt(pIniSection,L"FileCheckInverval",2000);
   dwAutoReloadTimeout = IniSectionGetInt(pIniSection,L"AutoReloadTimeout",2000);
 
-  iSciDirectWriteTech = IniSectionGetInt(pIniSection,L"SciDirectWriteTech",0);
+  iSciDirectWriteTech = IniSectionGetInt(pIniSection,L"SciDirectWriteTech", SC_TECHNOLOGY_DEFAULT);
   iSciDirectWriteTech = max(min(iSciDirectWriteTech,3),-1);
 
-  iSciFontQuality = IniSectionGetInt(pIniSection,L"SciFontQuality",3);
-  iSciFontQuality = max(min(iSciFontQuality,3),0);
+  iSciFontQuality = IniSectionGetInt(pIniSection,L"SciFontQuality", SC_EFF_QUALITY_DEFAULT);
+  iSciFontQuality = max(min(iSciFontQuality, SC_EFF_QUALITY_LCD_OPTIMIZED), SC_EFF_QUALITY_DEFAULT);
 
   iMarkOccurrencesCount = -1;
   iMarkOccurrencesMaxCount = IniSectionGetInt(pIniSection,L"MarkOccurrencesMaxCount",2000);
@@ -5933,7 +5933,7 @@ void LoadSettings()
   WCHAR tchSciFontQuality[32];
   StringCchPrintf(tchSciFontQuality,COUNTOF(tchSciFontQuality),L"%ix%i SciFontQuality",ResX,ResY);
   iSciFontQuality = IniSectionGetInt(pIniSection,tchSciFontQuality,iSciFontQuality);
-  iSciFontQuality = max(min(iSciFontQuality,3),0);
+  iSciFontQuality = max(min(iSciFontQuality, SC_EFF_QUALITY_LCD_OPTIMIZED), SC_TECHNOLOGY_DEFAULT);
 
 
   LocalFree(pIniSection);

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -1226,13 +1226,6 @@ LRESULT CALLBACK MainWndProc(HWND hwnd,UINT umsg,WPARAM wParam,LPARAM lParam)
     case WM_TRAYMESSAGE:
       return MsgTrayMessage(hwnd, wParam, lParam);
 
-    case WM_MOUSEWHEEL:
-    case WM_MBUTTONDOWN:
-      if (wParam & MK_MBUTTON) {
-        PostMessage(hwnd, WM_COMMAND, MAKELONG(BME_EDIT_BOOKMARKTOGGLE, 1), 0);
-      }
-      return DefWindowProc(hwnd, umsg, wParam, lParam);
-
     default:
       if (umsg == msgTaskbarCreated) {
         if (!IsWindowVisible(hwnd))

--- a/src/SciCall.h
+++ b/src/SciCall.h
@@ -159,6 +159,7 @@ DeclareSciCallV2(SetProperty, SETPROPERTY, const char *, key, const char *, valu
 //  SetTechnology
 //
 //
+DeclareSciCallV0(UnBufferedDraw, SETBUFFEREDDRAW);
 DeclareSciCallV1(SetTechnology, SETTECHNOLOGY, int, technology);
 
 

--- a/src/Styles.c
+++ b/src/Styles.c
@@ -4047,7 +4047,8 @@ BOOL Style_StrGetFontQuality(LPCWSTR lpszStyle,LPWSTR lpszQuality,int cchQuality
     if (StringCchCompareIN(tch,COUNTOF(tch),L"none",-1) == 0 ||
         StringCchCompareIN(tch,COUNTOF(tch),L"standard",-1) == 0 ||
         StringCchCompareIN(tch,COUNTOF(tch),L"cleartype",-1) == 0 ||
-        StringCchCompareIN(tch,COUNTOF(tch),L"default",-1) == 0) {
+        StringCchCompareIN(tch,COUNTOF(tch),L"default",-1) == 0) 
+    {
       StringCchCopyN(lpszQuality,cchQuality,tch,COUNTOF(tch));
       return TRUE;
     }
@@ -4549,7 +4550,7 @@ void Style_SetStyles(HWND hwnd,int iStyle,LPCWSTR lpszStyle)
 //
 void Style_SetFontQuality(HWND hwnd,LPCWSTR lpszStyle) {
 
-  WPARAM wQuality = (WPARAM)FontQuality[iSciFontQuality];;
+  WPARAM wQuality = (WPARAM)FontQuality[iSciFontQuality];
   WCHAR tch[BUFSIZE_STYLE_VALUE] = { L'\0' };
 
   if (Style_StrGetFontQuality(lpszStyle,tch,COUNTOF(tch))) {
@@ -4562,7 +4563,8 @@ void Style_SetFontQuality(HWND hwnd,LPCWSTR lpszStyle) {
     else if (StringCchCompareIN(tch,COUNTOF(tch),L"cleartype",-1) == 0)
       wQuality = SC_EFF_QUALITY_LCD_OPTIMIZED;
   }
-  else { // undefined, use general settings, except for special fonts
+  else if (wQuality == SC_EFF_QUALITY_DEFAULT) { 
+    // undefined, use general settings, except for special fonts
     if (Style_StrGetFont(lpszStyle,tch,COUNTOF(tch))) {
       if (StringCchCompareIN(tch,COUNTOF(tch),L"Calibri",-1) == 0 ||
           StringCchCompareIN(tch,COUNTOF(tch),L"Cambria",-1) == 0 ||


### PR DESCRIPTION
- Using of DirectWrite technology must be enabled explicitly now.
- Buffered drawing has been disabled, modern platforms are doing this internally