### PR TITLE
Fix: Use Standard Lexer on new (empty) files

### DIFF
--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -1159,11 +1159,9 @@ LRESULT CALLBACK MainWndProc(HWND hwnd,UINT umsg,WPARAM wParam,LPARAM lParam)
 
     // update Scintilla colors
     case WM_SYSCOLORCHANGE:
-      {
-        Style_SetLexer(g_hwndEdit,NULL); // uses current lexer
-        UpdateLineNumberWidth();
-        return DefWindowProc(hwnd,umsg,wParam,lParam);
-      }
+      SendMessage(g_hwndEdit, SCI_COLOURISE, 0, (LPARAM)-1);
+      UpdateLineNumberWidth();
+      return DefWindowProc(hwnd,umsg,wParam,lParam);
 
     //case WM_TIMER:
     //  return DefWindowProc(hwnd,umsg,wParam,lParam);

--- a/src/Styles.c
+++ b/src/Styles.c
@@ -3129,9 +3129,9 @@ void Style_SetLexer(HWND hwnd, PEDITLEXER pLexNew) {
   WCHAR wchFontName[64] = { '\0' };
   WCHAR wchCaretStyle[64] = { L'\0' };
 
-  // Select current if NULL is specified
+  // Select standard if NULL is specified
   if (!pLexNew) {
-    pLexNew = g_pLexCurrent; // initially current lexer is default lexer
+    pLexNew = &lexStandard;
   }
 
   // Lexer 


### PR DESCRIPTION
+ fix: set standard lexer (Default Text) on new (empty) files

Addressed Issue:  #252 