### PR TITLE
Relaxed UTF-8 encoding validation conditions

### DIFF
--- a/src/Dialogs.c
+++ b/src/Dialogs.c
@@ -64,9 +64,9 @@ extern DWORD dwLastIOError;
 extern bool bUseDefaultForFileEncoding;
 extern bool bSkipUnicodeDetection;
 extern bool bSkipANSICodePageDetection;
-extern bool bLoadASCIIasUTF8;
-extern bool bLoadNFOasOEM;
-extern bool bNoEncodingTags;
+extern bool g_bLoadASCIIasUTF8;
+extern bool g_bLoadNFOasOEM;
+extern bool g_bNoEncodingTags;
 extern bool bFixLineEndings;
 extern bool bAutoStripBlanks;
 
@@ -2255,9 +2255,9 @@ INT_PTR CALLBACK SelectDefEncodingDlgProc(HWND hwnd,UINT umsg,WPARAM wParam,LPAR
         CheckDlgButton(hwnd, IDC_USEASREADINGFALLBACK, DlgBtnChk(bUseDefaultForFileEncoding));
         CheckDlgButton(hwnd,IDC_NOUNICODEDETECTION, DlgBtnChk(bSkipUnicodeDetection));
         CheckDlgButton(hwnd, IDC_NOANSICPDETECTION, DlgBtnChk(bSkipANSICodePageDetection));
-        CheckDlgButton(hwnd,IDC_ASCIIASUTF8, DlgBtnChk(bLoadASCIIasUTF8));
-        CheckDlgButton(hwnd,IDC_NFOASOEM, DlgBtnChk(bLoadNFOasOEM));
-        CheckDlgButton(hwnd,IDC_ENCODINGFROMFILEVARS, DlgBtnChk(bNoEncodingTags));
+        CheckDlgButton(hwnd,IDC_ASCIIASUTF8, DlgBtnChk(g_bLoadASCIIasUTF8));
+        CheckDlgButton(hwnd,IDC_NFOASOEM, DlgBtnChk(g_bLoadNFOasOEM));
+        CheckDlgButton(hwnd,IDC_ENCODINGFROMFILEVARS, DlgBtnChk(g_bNoEncodingTags));
 
         CenterDlgInParent(hwnd);
       }
@@ -2277,9 +2277,9 @@ INT_PTR CALLBACK SelectDefEncodingDlgProc(HWND hwnd,UINT umsg,WPARAM wParam,LPAR
                 bUseDefaultForFileEncoding = (IsDlgButtonChecked(hwnd, IDC_USEASREADINGFALLBACK) == BST_CHECKED);
                 bSkipUnicodeDetection = (IsDlgButtonChecked(hwnd,IDC_NOUNICODEDETECTION) == BST_CHECKED);
                 bSkipANSICodePageDetection = (IsDlgButtonChecked(hwnd, IDC_NOANSICPDETECTION) == BST_CHECKED);
-                bLoadASCIIasUTF8 = (IsDlgButtonChecked(hwnd,IDC_ASCIIASUTF8) == BST_CHECKED);
-                bLoadNFOasOEM = (IsDlgButtonChecked(hwnd,IDC_NFOASOEM) == BST_CHECKED);
-                bNoEncodingTags = (IsDlgButtonChecked(hwnd,IDC_ENCODINGFROMFILEVARS) == BST_CHECKED);
+                g_bLoadASCIIasUTF8 = (IsDlgButtonChecked(hwnd,IDC_ASCIIASUTF8) == BST_CHECKED);
+                g_bLoadNFOasOEM = (IsDlgButtonChecked(hwnd,IDC_NFOASOEM) == BST_CHECKED);
+                g_bNoEncodingTags = (IsDlgButtonChecked(hwnd,IDC_ENCODINGFROMFILEVARS) == BST_CHECKED);
                 EndDialog(hwnd,IDOK);
               }
             }

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -228,10 +228,10 @@ bool      bViewEOLs;
 bool      bUseDefaultForFileEncoding;
 bool      bSkipUnicodeDetection;
 bool      bSkipANSICodePageDetection;
-bool      bLoadASCIIasUTF8 = false;
-bool      bForceLoadASCIIasUTF8 = false;
-bool      bLoadNFOasOEM;
-bool      bNoEncodingTags;
+bool      g_bLoadASCIIasUTF8 = false;
+bool      g_bForceLoadASCIIasUTF8 = false;
+bool      g_bLoadNFOasOEM;
+bool      g_bNoEncodingTags;
 bool      bFixLineEndings;
 bool      bAutoStripBlanks;
 int       iPrintHeader;
@@ -5314,10 +5314,10 @@ LRESULT MsgCommand(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
     case CMD_RELOADASCIIASUTF8:
       {
         if (StringCchLenW(g_wchCurFile,COUNTOF(g_wchCurFile))) {
-          bForceLoadASCIIasUTF8 = true;
+          g_bForceLoadASCIIasUTF8 = true;
           StringCchCopy(tchMaxPathBuffer,COUNTOF(tchMaxPathBuffer),g_wchCurFile);
           FileLoad(false, false, true, true, true, tchMaxPathBuffer);
-          bForceLoadASCIIasUTF8 = false;
+          g_bForceLoadASCIIasUTF8 = false;
         }
       }
       break;
@@ -5327,7 +5327,7 @@ LRESULT MsgCommand(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
     {
       g_bForceCompEncDetection = true;
       if (StringCchLenW(g_wchCurFile, COUNTOF(g_wchCurFile))) {
-        bForceLoadASCIIasUTF8 = false;
+        g_bForceLoadASCIIasUTF8 = false;
         StringCchCopy(tchMaxPathBuffer, COUNTOF(tchMaxPathBuffer), g_wchCurFile);
         FileLoad(false, false, true, false, false, tchMaxPathBuffer);
       }
@@ -5339,13 +5339,13 @@ LRESULT MsgCommand(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
       {
         if (StringCchLenW(g_wchCurFile,COUNTOF(g_wchCurFile))) {
           int _fNoFileVariables = g_flagNoFileVariables;
-          bool _bNoEncodingTags = bNoEncodingTags;
+          bool _bNoEncodingTags = g_bNoEncodingTags;
           g_flagNoFileVariables = 1;
-          bNoEncodingTags = 1;
+          g_bNoEncodingTags = 1;
           StringCchCopy(tchMaxPathBuffer,COUNTOF(tchMaxPathBuffer),g_wchCurFile);
           FileLoad(false,false,true, bSkipUnicodeDetection, bSkipANSICodePageDetection, tchMaxPathBuffer);
           g_flagNoFileVariables = _fNoFileVariables;
-          bNoEncodingTags = _bNoEncodingTags;
+          g_bNoEncodingTags = _bNoEncodingTags;
         }
       }
       break;
@@ -6884,11 +6884,11 @@ void LoadSettings()
 
     bSkipANSICodePageDetection = IniSectionGetBool(pIniSection, L"SkipANSICodePageDetection", true);
 
-    bLoadASCIIasUTF8 = IniSectionGetBool(pIniSection, L"LoadASCIIasUTF8", false);
+    g_bLoadASCIIasUTF8 = IniSectionGetBool(pIniSection, L"LoadASCIIasUTF8", false);
 
-    bLoadNFOasOEM = IniSectionGetBool(pIniSection, L"LoadNFOasOEM", true);
+    g_bLoadNFOasOEM = IniSectionGetBool(pIniSection, L"LoadNFOasOEM", true);
 
-    bNoEncodingTags = IniSectionGetBool(pIniSection, L"NoEncodingTags", false);
+    g_bNoEncodingTags = IniSectionGetBool(pIniSection, L"NoEncodingTags", false);
 
     g_iDefaultEOLMode = clampi(IniSectionGetInt(pIniSection, L"DefaultEOLMode", 0), 0, 2);
 
@@ -7197,9 +7197,9 @@ void SaveSettings(bool bSaveSettingsNow)
     IniSectionSetBool(pIniSection, L"UseDefaultForFileEncoding", bUseDefaultForFileEncoding);
     IniSectionSetBool(pIniSection, L"SkipUnicodeDetection", bSkipUnicodeDetection);
     IniSectionSetBool(pIniSection, L"SkipANSICodePageDetection", bSkipANSICodePageDetection);
-    IniSectionSetInt(pIniSection, L"LoadASCIIasUTF8", bLoadASCIIasUTF8);
-    IniSectionSetBool(pIniSection, L"LoadNFOasOEM", bLoadNFOasOEM);
-    IniSectionSetBool(pIniSection, L"NoEncodingTags", bNoEncodingTags);
+    IniSectionSetInt(pIniSection, L"LoadASCIIasUTF8", g_bLoadASCIIasUTF8);
+    IniSectionSetBool(pIniSection, L"LoadNFOasOEM", g_bLoadNFOasOEM);
+    IniSectionSetBool(pIniSection, L"NoEncodingTags", g_bNoEncodingTags);
     IniSectionSetInt(pIniSection, L"DefaultEOLMode", g_iDefaultEOLMode);
     IniSectionSetBool(pIniSection, L"FixLineEndings", bFixLineEndings);
     IniSectionSetBool(pIniSection, L"FixTrailingBlanks", bAutoStripBlanks);


### PR DESCRIPTION
+ fix: UTF-8 encoding detection: allow less reliable CED-Analysis of UTF-8 as soft-hint => prefer UTF-8