### PR TITLE
Small fixes for command-line-help dialog

### DIFF
--- a/src/Dialogs.c
+++ b/src/Dialogs.c
@@ -3137,7 +3137,10 @@ void CenterDlgInParent(HWND hDlg)
 
   HWND const hParent = GetParent(hDlg);
   RECT rcParent;
-  GetWindowRect(hParent, &rcParent);
+  if (hParent)
+    GetWindowRect(hParent, &rcParent);
+  else
+    GetWindowRect(GetDesktopWindow(), &rcParent);
 
   HMONITOR const hMonitor = MonitorFromRect(&rcParent, MONITOR_DEFAULTTONEAREST);
 
@@ -3165,7 +3168,7 @@ void CenterDlgInParent(HWND hDlg)
 
   SetWindowPos(hDlg, NULL, clampi(x, xMin, xMax), clampi(y, yMin, yMax), 0, 0, SWP_NOZORDER | SWP_NOSIZE);
 
-  //SnapToDefaultButton(hDlg);
+  //~SnapToDefaultButton(hDlg);
 }
 
 

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -555,12 +555,6 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
   // set AppUserModelID
   PrivateSetCurrentProcessExplicitAppUserModelID(Settings2.AppUserModelID);
 
-  // Command Line Help Dialog
-  if (s_flagDisplayHelp) {
-    DisplayCmdLineHelp(NULL);
-    return 0;
-  }
-
   // Adapt window class name
   if (s_flagIsElevated) {
     StringCchCat(s_wchWndClass, COUNTOF(s_wchWndClass), L"U");
@@ -649,6 +643,13 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
   if (s_hRichEdit == INVALID_HANDLE_VALUE) {
     //s_hRichEdit = LoadLibrary(L"RICHED20.DLL");  // Use RICHEDIT_CONTROL_VER for control in common_res.h
     s_hRichEdit = LoadLibrary(L"MSFTEDIT.DLL");  // Use "RichEdit50W" for control in common_res.h
+  }
+
+  // Command Line Help Dialog
+  if (s_flagDisplayHelp) {
+    DisplayCmdLineHelp(NULL);
+    _CleanUpResources(NULL, false);
+    return 0;
   }
 
   s_msgTaskbarCreated = RegisterWindowMessage(L"TaskbarCreated");


### PR DESCRIPTION
+ fix: load resources before displaying command-line-help dialog
+ fix: center dialog in case of missing parent window