### PR TITLE
Fix: ANSI CodePage detection (CED) - allow also less reliable results

### DIFF
--- a/src/Edit.c
+++ b/src/Edit.c
@@ -1052,7 +1052,8 @@ bool EditLoadFile(
   else if (iFileEncWeak != CPI_NONE) {
     iPreferedEncoding = iFileEncWeak;
   }
-  else if (!Encoding_IsNONE(iAnalyzedEncoding) && bIsReliable) {
+  // TODO: check switch for reliability in encoding settings
+  else if (!Encoding_IsNONE(iAnalyzedEncoding) /* && bIsReliable */) {
     iPreferedEncoding = iAnalyzedEncoding;
   } 
   else if (Encoding_IsNONE(iPreferedEncoding)) {

--- a/src/Version.h
+++ b/src/Version.h
@@ -65,7 +65,7 @@
 #if defined(_MSC_VER)
     #if (_MSC_VER >= 1916)
         #if(_MSC_FULL_VER >= 191627024) 
-            #define VER_CPL     MS Visual C++ 2017 v15.9.2
+            #define VER_CPL     MS Visual C++ 2017 v15.9.(2-3)
         #elif(_MSC_FULL_VER >= 191627023) 
             #define VER_CPL     MS Visual C++ 2017 v15.9.(0-1)
         #endif


### PR DESCRIPTION
+ chg: allow also "non reliable" CED detections for file decoding
+ chg: increasing VS version