### PR TITLE
Wrong shortcut to Recent file (History)

### DIFF
--- a/doc/KeyboardShortcuts.txt
+++ b/doc/KeyboardShortcuts.txt
@@ -14,7 +14,7 @@ Keyboard Shortcuts for Notepad3
     F6                    Save file as.
     Ctrl+F6               Save file copy.
     Ctrl+P                Print file.
-    Alt+H                 Open recent file.
+    Ctrl+Alt+H            Open recent file.
 
   Tools
 


### PR DESCRIPTION
The correct one is Ctrl+Alt+H, not Alt+H