### PR TITLE
MUI - Translation of Languages in es-es

### DIFF
--- a/language/np3_af_za/strings_af_za.rc
+++ b/language/np3_af_za/strings_af_za.rc
@@ -203,7 +203,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_be_by/strings_be_by.rc
+++ b/language/np3_be_by/strings_be_by.rc
@@ -203,7 +203,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_de_de/strings_de_de.rc
+++ b/language/np3_de_de/strings_de_de.rc
@@ -203,7 +203,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_en_gb/strings_en_gb.rc
+++ b/language/np3_en_gb/strings_en_gb.rc
@@ -231,7 +231,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_en_us/strings_en_us.rc
+++ b/language/np3_en_us/strings_en_us.rc
@@ -231,7 +231,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_es_es/strings_es_es.rc
+++ b/language/np3_es_es/strings_es_es.rc
@@ -197,22 +197,22 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_MUI_MENU_LANGUAGE   "Language"
-    IDS_MUI_LANG_EN_US      "English (United States)\t\t\t[%s]"                 
-    IDS_MUI_LANG_AF_ZA      "Afrikaans (South Africa)\t\t\t[%s]"               
-    IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
-    IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
-    IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
-    IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
-    IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
-    IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         
-    IDS_MUI_LANG_JP_JP      "Japanese (Japan)\t\t\t[%s]"                        
-    IDS_MUI_LANG_KO_KR      "Korean (Korea)\t\t\t[%s]"                          
-    IDS_MUI_LANG_NL_NL      "Dutch (Netherlands)\t\t\t[%s]"                    
-    IDS_MUI_LANG_PT_BR      "Portuguese (Brazil)\t\t\t[%s]"                     
-    IDS_MUI_LANG_RU_RU      "Russian (Russia)\t\t\t[%s]"                        
-    IDS_MUI_LANG_ZH_CN      "Chinese (Hans)\t\t\t[%s]"                         
+    IDS_MUI_MENU_LANGUAGE   "Idioma"
+    IDS_MUI_LANG_EN_US      "Inglés (Estados Unidos)\t\t\t[%s]"                 
+    IDS_MUI_LANG_AF_ZA      "Afrikáans (Sudáfrica)\t\t\t[%s]"               
+    IDS_MUI_LANG_BE_BY      "Bielorruso (Belarús)\t\t\t[%s]"                    
+    IDS_MUI_LANG_DE_DE      "Alemán (Alemania)\t\t\t[%s]"                        
+    IDS_MUI_LANG_EN_GB      "Inglés (Reino Unido)\t\t\t[%s]"                
+    IDS_MUI_LANG_ES_ES      "Español (España)\t\t\t[%s]"                  
+    IDS_MUI_LANG_FR_FR      "Francés (Francia)\t\t\t[%s]"                        
+    IDS_MUI_LANG_HU_HU      "Húngaro (Hungría)\t\t\t[%s]"                     
+    IDS_MUI_LANG_IT_IT      "Italiano (Italia)\t\t\t[%s]"                         
+    IDS_MUI_LANG_JP_JP      "Japonés (Japón)\t\t\t[%s]"                        
+    IDS_MUI_LANG_KO_KR      "Coreano (Corea)\t\t\t[%s]"                          
+    IDS_MUI_LANG_NL_NL      "Neerlandés (Países Bajos)\t\t\t[%s]"                    
+    IDS_MUI_LANG_PT_BR      "Portugués (Brasil)\t\t\t[%s]"                     
+    IDS_MUI_LANG_RU_RU      "Ruso (Rusia)\t\t\t[%s]"                        
+    IDS_MUI_LANG_ZH_CN      "Chino (Hans)\t\t\t[%s]"                         
 END
 
 STRINGTABLE

--- a/language/np3_fr_fr/strings_fr_fr.rc
+++ b/language/np3_fr_fr/strings_fr_fr.rc
@@ -201,7 +201,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_hu_hu/strings_hu_hu.rc
+++ b/language/np3_hu_hu/strings_hu_hu.rc
@@ -231,7 +231,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_it_it/strings_it_it.rc
+++ b/language/np3_it_it/strings_it_it.rc
@@ -231,7 +231,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_ja_jp/strings_ja_jp.rc
+++ b/language/np3_ja_jp/strings_ja_jp.rc
@@ -203,7 +203,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_ko_kr/strings_ko_kr.rc
+++ b/language/np3_ko_kr/strings_ko_kr.rc
@@ -223,7 +223,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_nl_nl/strings_nl_nl.rc
+++ b/language/np3_nl_nl/strings_nl_nl.rc
@@ -203,7 +203,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_pt_br/strings_pt_br.rc
+++ b/language/np3_pt_br/strings_pt_br.rc
@@ -231,7 +231,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_ru_ru/strings_ru_ru.rc
+++ b/language/np3_ru_ru/strings_ru_ru.rc
@@ -203,7 +203,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         

--- a/language/np3_zh_cn/strings_zh_cn.rc
+++ b/language/np3_zh_cn/strings_zh_cn.rc
@@ -203,7 +203,7 @@ BEGIN
     IDS_MUI_LANG_BE_BY      "Belarusian (Belarus)\t\t\t[%s]"                    
     IDS_MUI_LANG_DE_DE      "German (Germany)\t\t\t[%s]"                        
     IDS_MUI_LANG_EN_GB      "English (United Kingdom)\t\t\t[%s]"                
-    IDS_MUI_LANG_ES_ES      "Spanish (Spain Modern)\t\t\t[%s]"                  
+    IDS_MUI_LANG_ES_ES      "Spanish (Spain)\t\t\t[%s]"                  
     IDS_MUI_LANG_FR_FR      "French (France)\t\t\t[%s]"                        
     IDS_MUI_LANG_HU_HU      "Hungarian (Hungary)\t\t\t[%s]"                     
     IDS_MUI_LANG_IT_IT      "Italian (Italy)\t\t\t[%s]"                         


### PR DESCRIPTION
- Suppress " Modern" because it"s relative to "Sort(ing)" and not to "Spain"