### PR TITLE
Don't copy complete Hyperlink, if only parts are selected

### DIFF
--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -3670,8 +3670,10 @@ LRESULT MsgCommand(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
       if (s_flagPasteBoard) {
         s_bLastCopyFromMe = true;
       }
-      if (!HandleHotSpotURL(SciCall_GetCurrentPos(), COPY_HYPERLINK)) {
-        SciCall_CopyAllowLine();
+      if (!SciCall_IsSelectionEmpty() || 
+          !HandleHotSpotURL(SciCall_GetCurrentPos(), COPY_HYPERLINK))
+      {
+          SciCall_CopyAllowLine();
       }
       UpdateToolbar();
       break;


### PR DESCRIPTION
+ chg: in case of (partial) selection, copy only selection instead of complete hyperlink (issue #1296)