### PR TITLE
Update ScintillaWin.cxx (Hold Right Mouse Button and Scroll Mouse Wheel to Cycle Through Undo History Forward and Backwards)

### DIFF
--- a/scintilla/win32/ScintillaWin.cxx
+++ b/scintilla/win32/ScintillaWin.cxx
@@ -1447,6 +1447,15 @@ sptr_t ScintillaWin::WndProc(unsigned int iMessage, uptr_t wParam, sptr_t lParam
 
 			// Either SCROLL or ZOOM. We handle the wheel steppings calculation
 			wheelDelta -= GET_WHEEL_DELTA_WPARAM(wParam);
+
+			// Hold RIGHT MOUSE BUTTON and SCROLL to cycle through UNDO history
+			if (wParam & MK_RBUTTON) {
+				if (wheelDelta >= 0)
+					Redo();
+				else
+					Undo();
+			}
+
 			if (std::abs(wheelDelta) >= WHEEL_DELTA && linesPerScroll > 0) {
 				Sci::Line linesToScroll = linesPerScroll;
 				if (linesPerScroll == WHEEL_PAGESCROLL)


### PR DESCRIPTION
This is a small pull request to add a simple feature:
Hold down the right mouse button and scroll with the mouse wheel to cycle through the change history of the document.  It works fast and well.  Hopefully you'll accept the feature, as I think it's really cool!

This was a test of my ability to read through the Notepad3 code for the first time. I spent hours learning the code base today and learning my way around VS2019 Community edition. Please be gentle.. This is my first pull request ever!

