### PR TITLE
Encoding (Default) Settings dialog: use positive wording for all items

### DIFF
--- a/Build/Changes.txt
+++ b/Build/Changes.txt
@@ -44,7 +44,6 @@ NEW:
 --------------------------------------------------
 CHANGES:
 --------------------------------------------------
-- MiniPath file name extension "Filter" config as "LoadOrder"
 - Sync Minipath Filter-Lines list with Notepad3 Lexers list
 - Use double-quotes as MRU list string limiter
 - Keep .ini backward compatibility for moved "Text Files" lexer (from "Default Text")
@@ -53,8 +52,6 @@ CHANGES:
 - To force UTF-8 as preffered encoding: activate encoding detection failure fallback for default encoding
 - Allow Fixedsys font for GDI rendering
 - Color MarkOccurrences refactoring: use System's HighLight color as default (alpha:60)
-- Oniguruma: support static build
-- Merge current (v.6.9.2) Oniguruma docs
 - Replace Onigmo by Oniguruma
 - CED -> UCHARDET license and acknowledgement
 

--- a/language/np3_de_de/dialogs_de_de.rc
+++ b/language/np3_de_de/dialogs_de_de.rc
@@ -191,11 +191,11 @@ BEGIN
                     "Button", BS_AUTOCHECKBOX | WS_TABSTOP,14,82,122,10
     CONTROL         "Öffne 8-bit *.&nfo/diz Dateien als DOS-437.",IDC_NFOASOEM,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,94,165,10
-    CONTROL         "Keine Codierungs-&Tags der Datei nutzen.",IDC_ENCODINGFROMFILEVARS,
+    CONTROL         "Nutze Codierungs-&Tags aus der Datei.",IDC_ENCODINGFROMFILEVARS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,106,165,10
-    CONTROL         "Keine &ANSI Code-Page Erkennung.",IDC_NOANSICPDETECTION,
+    CONTROL         "Führe &ANSI Code-Page Analyse durch.",IDC_NOANSICPDETECTION,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,118,165,10
-    CONTROL         "Keine &UNICODE Erkennung.",IDC_NOUNICODEDETECTION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,130,122,10
+    CONTROL         "Erlaube &UNICODE Erkennung.",IDC_NOUNICODEDETECTION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,130,122,10
     DEFPUSHBUTTON   "OK",IDOK,87,151,50,14
     PUSHBUTTON      "Abbrechen",IDCANCEL,140,151,50,14
 END

--- a/language/np3_en_gb/dialogs_en_gb.rc
+++ b/language/np3_en_gb/dialogs_en_gb.rc
@@ -191,11 +191,11 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,82,122,10
     CONTROL         "Open 8-bit *.&nfo/diz files in DOS-437 mode.",IDC_NFOASOEM,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,94,155,10
-    CONTROL         "Don't parse encoding file &tags.",IDC_ENCODINGFROMFILEVARS,
+    CONTROL         "Parse encoding file &tags.",IDC_ENCODINGFROMFILEVARS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,106,126,10
-    CONTROL         "Skip &ANSI Code Page detection.",IDC_NOANSICPDETECTION,
+    CONTROL         "Perform &ANSI Code Page analysis.",IDC_NOANSICPDETECTION,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,118,122,10
-    CONTROL         "Skip &UNICODE detection.",IDC_NOUNICODEDETECTION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,130,122,10
+    CONTROL         "Enable &UNICODE detection.",IDC_NOUNICODEDETECTION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,130,122,10
     DEFPUSHBUTTON   "OK",IDOK,87,151,50,14
     PUSHBUTTON      "Cancel",IDCANCEL,140,151,50,14
 END

--- a/language/np3_en_us/dialogs_en_us.rc
+++ b/language/np3_en_us/dialogs_en_us.rc
@@ -191,11 +191,11 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,82,122,10
     CONTROL         "Open 8-bit *.&nfo/diz files in DOS-437 mode.",IDC_NFOASOEM,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,94,155,10
-    CONTROL         "Don't parse encoding file &tags.",IDC_ENCODINGFROMFILEVARS,
+    CONTROL         "Parse encoding file &tags.",IDC_ENCODINGFROMFILEVARS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,106,126,10
-    CONTROL         "Skip &ANSI Code Page detection.",IDC_NOANSICPDETECTION,
+    CONTROL         "Perform &ANSI Code Page analysis.",IDC_NOANSICPDETECTION,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,118,122,10
-    CONTROL         "Skip &UNICODE detection.",IDC_NOUNICODEDETECTION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,130,122,10
+    CONTROL         "Enable &UNICODE detection.",IDC_NOUNICODEDETECTION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,130,122,10
     DEFPUSHBUTTON   "OK",IDOK,87,151,50,14
     PUSHBUTTON      "Cancel",IDCANCEL,140,151,50,14
 END

--- a/src/Dialogs.c
+++ b/src/Dialogs.c
@@ -2544,9 +2544,9 @@ static INT_PTR CALLBACK SelectDefEncodingDlgProc(HWND hwnd, UINT umsg, WPARAM wP
     CheckDlgButton(hwnd, IDC_ASCIIASUTF8, SetBtn(s_bLoadASCIIasUTF8));
     CheckDlgButton(hwnd, IDC_RELIABLE_DETECTION_RES, SetBtn(Settings.UseReliableCEDonly));
     CheckDlgButton(hwnd, IDC_NFOASOEM, SetBtn(Settings.LoadNFOasOEM));
-    CheckDlgButton(hwnd, IDC_ENCODINGFROMFILEVARS, SetBtn(Settings.NoEncodingTags));
-    CheckDlgButton(hwnd, IDC_NOUNICODEDETECTION, SetBtn(Settings.SkipUnicodeDetection));
-    CheckDlgButton(hwnd, IDC_NOANSICPDETECTION, SetBtn(Settings.SkipANSICodePageDetection));
+    CheckDlgButton(hwnd, IDC_ENCODINGFROMFILEVARS, SetBtn(!Settings.NoEncodingTags));
+    CheckDlgButton(hwnd, IDC_NOUNICODEDETECTION, SetBtn(!Settings.SkipUnicodeDetection));
+    CheckDlgButton(hwnd, IDC_NOANSICPDETECTION, SetBtn(!Settings.SkipANSICodePageDetection));
 
     DialogEnableControl(hwnd, IDC_USEASREADINGFALLBACK, Encoding_IsASCII(s_iEnc));
 
@@ -2629,9 +2629,9 @@ static INT_PTR CALLBACK SelectDefEncodingDlgProc(HWND hwnd, UINT umsg, WPARAM wP
           Settings.LoadASCIIasUTF8 = IsButtonChecked(hwnd, IDC_ASCIIASUTF8);
           Settings.UseReliableCEDonly = IsButtonChecked(hwnd, IDC_RELIABLE_DETECTION_RES);
           Settings.LoadNFOasOEM = IsButtonChecked(hwnd, IDC_NFOASOEM);
-          Settings.NoEncodingTags = IsButtonChecked(hwnd, IDC_ENCODINGFROMFILEVARS);
-          Settings.SkipUnicodeDetection = IsButtonChecked(hwnd, IDC_NOUNICODEDETECTION);
-          Settings.SkipANSICodePageDetection = IsButtonChecked(hwnd, IDC_NOANSICPDETECTION);
+          Settings.NoEncodingTags = !IsButtonChecked(hwnd, IDC_ENCODINGFROMFILEVARS);
+          Settings.SkipUnicodeDetection = !IsButtonChecked(hwnd, IDC_NOUNICODEDETECTION);
+          Settings.SkipANSICodePageDetection = !IsButtonChecked(hwnd, IDC_NOANSICPDETECTION);
           EndDialog(hwnd, IDOK);
         }
       }

--- a/src/Edit.c
+++ b/src/Edit.c
@@ -1211,7 +1211,7 @@ bool EditLoadFile(
     cpi_enc_t const iFileVarEncoding = (FileVars_IsValidEncoding(&Globals.fvCurFile) && !Settings.NoEncodingTags) ?
       FileVars_GetEncoding(&Globals.fvCurFile) : CPI_NONE;
 
-    if (!Encoding_IsNONE(iFileVarEncoding)) { 
+    if (!Encoding_IsNONE(iFileVarEncoding) && !bForceEncDetection) {
       iForcedEncoding = (Globals.fvCurFile.mask & FV_ENCODING) ? iFileVarEncoding : iForcedEncoding;
     }
 


### PR DESCRIPTION
@hpwamr : Wording changed for en-US,en-GB,de-DE - please change all remaining languages accordingly.