### PR TITLE
Relax UTF-8 orientation

### DIFF
--- a/Build/Notepad3.ini
+++ b/Build/Notepad3.ini
@@ -46,7 +46,7 @@ SettingsVersion=4
 ;UndoTransactionTimeout=0
 ;AdministrationTool.exe=
 ;DevDebugMode=0
-;AnalyzeReliableConfidenceLevel=67
+;AnalyzeReliableConfidenceLevel=50
 [Statusbar Settings]
 ;VisibleSections=0 1 12 14 2 4 5 6 7 8 9 10 11
 ;SectionPrefixes=Ln  ,Col  ,Sel  ,Sb  ,SLn  ,Occ  ,,,,,,,Ch  ,Repl  ,Eval  ,

--- a/src/Config/Config.cpp
+++ b/src/Config/Config.cpp
@@ -684,7 +684,7 @@ void LoadSettings()
     Settings2.CurrentLineVerticalSlop = clampi(IniSectionGetInt(Settings2_Section, L"CurrentLineVerticalSlop", Defaults2.CurrentLineVerticalSlop), 0, 25);
 
 
-    int const iARCLdef = 67;
+    int const iARCLdef = 50;
     Defaults2.AnalyzeReliableConfidenceLevel = (float)iARCLdef / 100.0f;
     int const iARCLset = clampi(IniSectionGetInt(Settings2_Section, L"AnalyzeReliableConfidenceLevel", iARCLdef), 0, 100);
     Settings2.AnalyzeReliableConfidenceLevel = (float)iARCLset / 100.0f;
@@ -866,7 +866,7 @@ void LoadSettings()
     auto const iPrefEncIniSetting = (cpi_enc_t)Encoding_MapIniSetting(false, (int)CPI_UTF8);
     GET_ENC_VALUE_FROM_INISECTION(DefaultEncoding, iPrefEncIniSetting, CPI_NONE, INT_MAX);
     Settings.DefaultEncoding = ((Settings.DefaultEncoding == CPI_NONE) ? CPI_UTF8 : (cpi_enc_t)Encoding_MapIniSetting(true, (int)Settings.DefaultEncoding));
-    GET_BOOL_VALUE_FROM_INISECTION(UseDefaultForFileEncoding, true);
+    GET_BOOL_VALUE_FROM_INISECTION(UseDefaultForFileEncoding, false);
     GET_BOOL_VALUE_FROM_INISECTION(LoadASCIIasUTF8, true);
     GET_BOOL_VALUE_FROM_INISECTION(UseReliableCEDonly, true);
     GET_BOOL_VALUE_FROM_INISECTION(LoadNFOasOEM, true);


### PR DESCRIPTION
lower confidence level for UCHARDET and use system's code-page as detection fallback by default)