### PR TITLE
 language/np3_zh_cn: Update translation for zh_CN.

### DIFF
--- a/language/np3_zh_cn/menu_zh_cn.rc
+++ b/language/np3_zh_cn/menu_zh_cn.rc
@@ -319,7 +319,7 @@ BEGIN
         MENUITEM "提示配对括号(&V)\tCtrl+Shift+V",             IDM_VIEW_MATCHBRACES
         POPUP "高亮当前行(&G)\tCtrl+Shift+I"
         BEGIN
-            MENUITEM "清除高亮(&N)",                          IDM_VIEW_HILITCURLN_NONE
+            MENUITEM "无高亮(&N)",                          IDM_VIEW_HILITCURLN_NONE
             MENUITEM "背景颜色(&C)",                          IDM_VIEW_HILITCURLN_BACK
             MENUITEM "边框(&F)",                              IDM_VIEW_HILITCURLN_FRAME
         END


### PR DESCRIPTION
Signed-off-by: Liu Hao <lh_mouse@126.com>

Replace the verb with an adverb in **No highlight**. This mistake has been there long ago. :joy: