### PR TITLE
+Fix - Corrected the encoding to ANSI (remove utf-8 Signature)

### DIFF
--- a/minipath/language/mp_es_es/resource.h
+++ b/minipath/language/mp_es_es/resource.h
@@ -1,4 +1,4 @@
-﻿Unicode (UTF-8) Signature//{{NO_DEPENDENCIES}}
+//{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
 // Used by mp_en_gb.rc
 //


### PR DESCRIPTION
- This error is detected with the test of new "rcdll.dll"