### PR TITLE
ja_jp: huge file, adjust

### DIFF
--- a/language/np3_ja_jp/dialogs_ja_jp.rc
+++ b/language/np3_ja_jp/dialogs_ja_jp.rc
@@ -186,17 +186,17 @@ BEGIN
     CONTROL         "判別に失敗したら代替して開く(非互換)(&F)",IDC_USEASREADINGFALLBACK,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,38,155,10
     GROUPBOX        "文字コード判別: ",IDC_STATIC,7,58,183,88,0,WS_EX_TRANSPARENT
-    CONTROL         "7-bit ASCIIはUTF-8モードで開く(&A)",IDC_ASCIIASUTF8,
+    CONTROL         "7-bit ASCII は UTF-8 モードで開く(&A)",IDC_ASCIIASUTF8,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,70,136,10
     CONTROL         "信頼できる検出結果のみを利用(&R)",IDC_RELIABLE_DETECTION_RES,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,82,122,10
-    CONTROL         "8-bit のnfo/dizファイルはDOS-437モードで開く(&N)",IDC_NFOASOEM,
+    CONTROL         "8-bit nfo/diz ファイルは DOS-437 モードで開く(&N)",IDC_NFOASOEM,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,94,165,10
     CONTROL         "タグ中の文字コードの指定を解析する(&T)",IDC_ENCODINGFROMFILEVARS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,106,153,10
-    CONTROL         "ANSIを判別する(&A)",IDC_NOANSICPDETECTION,
+    CONTROL         "ANSI を判別する(&A)",IDC_NOANSICPDETECTION,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,118,122,10
-    CONTROL         "Unicodeを判別する(&U)",IDC_NOUNICODEDETECTION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,130,122,10
+    CONTROL         "Unicode を判別する(&U)",IDC_NOUNICODEDETECTION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,130,122,10
     DEFPUSHBUTTON   "OK",IDOK,87,151,50,14
     PUSHBUTTON      "キャンセル",IDCANCEL,140,151,50,14
 END
@@ -269,12 +269,12 @@ END
 
 IDD_MUI_CHANGENOTIFY DIALOGEX 0, 0, 184, 65
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "ファイルの変更時の通知"
+CAPTION "ファイルの変更の通知"
 FONT 8, "MS Shell Dlg", 0, 0, 0x0
 BEGIN
     CONTROL         "無し(&N)",100,"Button",BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,7,7,99,10
     CONTROL         "メッセージを表示(&D)",101,"Button",BS_AUTORADIOBUTTON | WS_TABSTOP,7,19,106,10
-    CONTROL         "自動再読み込み(修正不可能)(&A)",102,"Button",BS_AUTORADIOBUTTON | WS_TABSTOP,7,31,114,10
+    CONTROL         "自動再読み込み(修正不可)(&A)",102,"Button",BS_AUTORADIOBUTTON | WS_TABSTOP,7,31,114,10
     CONTROL         "新たにファイルを開いたらリセット(&R)",103,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,48,165,10
     DEFPUSHBUTTON   "OK",IDOK,127,7,50,14
     PUSHBUTTON      "キャンセル",IDCANCEL,127,24,50,14
@@ -338,7 +338,7 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,71,201,10
     CONTROL         "一貫性のないインデントを警告(&W)",IDC_WARN_INCONSISTENT_INDENTS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,83,150,10
-    CONTROL         "読み込み時にタブ/空白の多数派を自動検出(&A)",IDC_AUTO_DETECT_INDENTS,
+    CONTROL         "読み込み時にタブ/空白の多数派を検出(&A)",IDC_AUTO_DETECT_INDENTS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,95,150,10
     DEFPUSHBUTTON   "OK",IDOK,117,7,50,14
     PUSHBUTTON      "キャンセル",IDCANCEL,117,27,50,14
@@ -635,10 +635,10 @@ BEGIN
     CONTROL         "それしかない行を削除(&U)",105,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,74,104,10
     CONTROL         "空行を削除(&E)",106,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,86,104,10
     CONTROL         "空白文字の行を削除(&W)",107,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,98,104,10
-    CONTROL         "大文字/小文字を区別する(&S).",108,"Button",BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,7,115,104,10
-    CONTROL         "大文字/小文字を区別しない(&C)",109,"Button",BS_AUTORADIOBUTTON | WS_TABSTOP,7,127,104,10
+    CONTROL         "大文字小文字を区別(&S)",108,"Button",BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,7,115,104,10
+    CONTROL         "大文字小文字の区別なし(&C)",109,"Button",BS_AUTORADIOBUTTON | WS_TABSTOP,7,127,104,10
     CONTROL         "論理番号で比較(&N)",110,"Button",BS_AUTORADIOBUTTON | WS_TABSTOP,7,139,104,10
-    CONTROL         "辞書式的に並べ替え(&L)",111,"Button",BS_AUTORADIOBUTTON | WS_TABSTOP,7,151,104,10
+    CONTROL         "辞書式に並べ替え(&L)",111,"Button",BS_AUTORADIOBUTTON | WS_TABSTOP,7,151,104,10
     CONTROL         "列でソート (Altで矩形選択) (&S)",112,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,168,131,10
     DEFPUSHBUTTON   "OK",IDOK,128,7,50,14
     PUSHBUTTON      "キャンセル",IDCANCEL,128,24,50,14

--- a/language/np3_ja_jp/menu_ja_jp.rc
+++ b/language/np3_ja_jp/menu_ja_jp.rc
@@ -257,14 +257,14 @@ BEGIN
             MENUITEM "日付と時刻(年月日)(&L)\tCtrl+Shift+F5",      IDM_EDIT_INSERT_LONGDATE
             MENUITEM "日付と時刻の更新(&U)\tShift+F5",             CMD_TIMESTAMPS
             MENUITEM SEPARATOR
-            MENUITEM "行コメント(切り替え)(&L)\tCtrl+Q",              IDM_EDIT_LINECOMMENT
+            MENUITEM "行コメント(切替)(&L)\tCtrl+Q",              IDM_EDIT_LINECOMMENT
             MENUITEM "ブロックコメント(&S)\tCtrl+Shift+Q",             IDM_EDIT_STREAMCOMMENT
         END
         POPUP "プログラム(&M)"
         BEGIN
             MENUITEM "GUIDをクリップボードにコピー(&G)\tCtrl+Shift+.",     IDM_EDIT_INSERT_GUID
             MENUITEM SEPARATOR
-            MENUITEM "文字列型中のエスケープ文字を変換(&E)\tCtrl+Alt+E", IDM_EDIT_ESCAPECCHARS
+            MENUITEM "文字列型中のエスケープ文字変換(&E)\tCtrl+Alt+E", IDM_EDIT_ESCAPECCHARS
             MENUITEM "文字列型中の上記アンエスケープ(&U)\tCtrl+Alt+R",   IDM_EDIT_UNESCAPECCHARS
             MENUITEM SEPARATOR
             MENUITEM "数値を1増加\tCtrl+Alt+NK+",                    CMD_INCREASENUM
@@ -284,7 +284,7 @@ BEGIN
         MENUITEM SEPARATOR
         POPUP "ブックマーク(しおり)(&K)"
         BEGIN
-            MENUITEM "指定の切り替え(&T)\tCtrl+F2",                BME_EDIT_BOOKMARKTOGGLE
+            MENUITEM "指定の切替(&T)\tCtrl+F2",                BME_EDIT_BOOKMARKTOGGLE
             MENUITEM SEPARATOR
             MENUITEM "次へ(&N)\tF2",                              BME_EDIT_BOOKMARKNEXT
             MENUITEM "前へ(&T)\tShift+F2",                        BME_EDIT_BOOKMARKPREV
@@ -295,7 +295,7 @@ BEGIN
         POPUP "検索(&S)"
         BEGIN
             MENUITEM "検索(&F)...\tCtrl+F",                      IDM_EDIT_FIND
-            MENUITEM "検索文字列の候補に追加\tAlt+F3",             IDM_EDIT_SAVEFIND
+            MENUITEM "検索文字列候補に追加\tAlt+F3",             IDM_EDIT_SAVEFIND
             MENUITEM "次を検索(&X)\tF3",                          IDM_EDIT_FINDNEXT
             MENUITEM "前へ検索(&V)\tShift+F3",                    IDM_EDIT_FINDPREV
             MENUITEM "選択部分で次を検索\tCtrl+F3",                CMD_FINDNEXTSEL
@@ -321,7 +321,7 @@ BEGIN
         POPUP "現在の行を強調表示(&G)\tCtrl+Shift+I"
         BEGIN
             MENUITEM "無し(&N)",                             IDM_VIEW_HILITCURLN_NONE
-            MENUITEM "背景色を変える(&C)",                     IDM_VIEW_HILITCURLN_BACK
+            MENUITEM "背景色を変更(&C)",                     IDM_VIEW_HILITCURLN_BACK
             MENUITEM "枠線(&F)",                             IDM_VIEW_HILITCURLN_FRAME
         END
         POPUP "単語出現マーカー(&k)"
@@ -331,7 +331,7 @@ BEGIN
             MENUITEM "単語一望モードを無効に",                   IDM_VIEW_MARKOCCUR_VISIBLE
             MENUITEM SEPARATOR
             MENUITEM "大文字小文字を区別(&C)",                 IDM_VIEW_MARKOCCUR_CASE
-            POPUP "単語全体が一致(&W)"
+            POPUP "単語単位で一致(&W)"
             BEGIN
                 MENUITEM "オフ",                              IDM_VIEW_MARKOCCUR_WNONE
                 MENUITEM "選択単語に一致(&S)",                IDM_VIEW_MARKOCCUR_WORD
@@ -355,9 +355,9 @@ BEGIN
         BEGIN
             MENUITEM "メニューバーを表示(&M)",                       IDM_VIEW_MENUBAR
             MENUITEM "ツールバーを表示(&T)",                        IDM_VIEW_TOOLBAR
-            MENUITEM "アイコン大小の切り替え(&G)",                   IDM_VIEW_TOGGLETB
+            MENUITEM "アイコン大小の切替(&G)",                   IDM_VIEW_TOGGLETB
             MENUITEM "ツールバーの編集(&C)...",                     IDM_VIEW_CUSTOMIZETB
-            MENUITEM "ツールバー用独自アイコンを設定(&L)...",          IDM_VIEW_LOADTHEMETB
+            MENUITEM "独自アイコンを設定(&L)...",          IDM_VIEW_LOADTHEMETB
             MENUITEM "ステータスバーを表示(&S)",                     IDM_VIEW_STATUSBAR
         END
         POPUP "拡大縮小(&Z)"
@@ -373,7 +373,7 @@ BEGIN
             MENUITEM "初期化位置として記憶",                         CMD_SAVEASDEFWINPOS
             MENUITEM "記憶した初期化位置を消去",                     CMD_CLEARSAVEDWINPOS
             MENUITEM "最初の位置へ移動\tCtrl+F11",                  CMD_INITIALWINPOS
-            MENUITEM "全画面表示の切り替え\tF11",                    CMD_FULLSCRWINPOS
+            MENUITEM "全画面表示の切替\tF11",                    CMD_FULLSCRWINPOS
             MENUITEM "ウィンドウ位置の固定(&P)",                      IDM_VIEW_STICKYWINPOS
         END
     END
@@ -402,7 +402,7 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "単一インスタンスでファイルを開く(&F)",                IDM_VIEW_SINGLEFILEINSTANCE
         MENUITEM "ファイルの変更を通知する(&C)...\tAlt+F5",          IDM_VIEW_CHANGENOTIFY
-        MENUITEM "メッセージ時の効果音をミュート(&B)",                  IDM_VIEW_MUTE_MESSAGEBEEP
+        MENUITEM "メッセージの効果音をミュート(&B)",                  IDM_VIEW_MUTE_MESSAGEBEEP
         POPUP "Escキーの動作(&K)"
         BEGIN
             MENUITEM "何もしない(&N)",                          IDM_VIEW_NOESCFUNC
@@ -480,7 +480,7 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "すべて選択(&S)",                              IDM_EDIT_SELECTALL
         MENUITEM SEPARATOR
-        MENUITEM "ここの折りたたみを切り替え(&T)",                   IDM_VIEW_TOGGLE_CURRENT_FOLD
+        MENUITEM "ここの折りたたみを切替(&T)",                   IDM_VIEW_TOGGLE_CURRENT_FOLD
         MENUITEM SEPARATOR
         MENUITEM "ウェブ1で開く(&1)",                             CMD_WEBACTION1
         MENUITEM "ウェブ2で開く(&2)",                             CMD_WEBACTION2
@@ -490,9 +490,9 @@ BEGIN
     BEGIN
         MENUITEM "メニューバーを表示(&M)",                        IDM_VIEW_MENUBAR
         MENUITEM "ツールバーの表示(&T)",                         IDM_VIEW_TOOLBAR
-        MENUITEM "アイコン大小の切り替え(&G)",                    IDM_VIEW_TOGGLETB
+        MENUITEM "アイコン大小の切替(&G)",                    IDM_VIEW_TOGGLETB
         MENUITEM "ツールバーの編集(&C)...",                      IDM_VIEW_CUSTOMIZETB
-        MENUITEM "ツールバー用独自アイコンを設定(&L)...",           IDM_VIEW_LOADTHEMETB
+        MENUITEM "ツールバーの独自アイコンを設定(&L)...",           IDM_VIEW_LOADTHEMETB
         MENUITEM "ステータスバーの表示(&S)",                      IDM_VIEW_STATUSBAR
     END
     POPUP "+"

--- a/language/np3_ja_jp/strings_ja_jp.rc
+++ b/language/np3_ja_jp/strings_ja_jp.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_MUI_ERR_ADMINEXE    "管理ツールが見つかりません。\nNotepad3の公式サイトを開きますか？ https://rizonesoft.com"
     IDS_MUI_WARN_LOAD_BIG_FILE
                             "大容量のファイルです。このファイルを開きますか？"
-    IDS_MUI_ERR_FILE_TOO_LARGE "Can't handle that huge file (size: %lli MB)!"
+    IDS_MUI_ERR_FILE_TOO_LARGE "大容量すぎて処理できません！ (サイズ: %lli MB)"
     IDS_MUI_WARN_UNKNOWN_EXT
                             "%s は設定のない拡張子です。\n読み込みますか ？"
     IDS_MUI_INDENT_CONSISTENT  "インデントは一貫しています。"


### PR DESCRIPTION
Translation for new huge files. And, Adjusted overall.

I noticed there. The top position of "X Time" is a little higher. We should move this down a little.

In `dialogs.rc` :
```
CAPTION "Insert HTML/XML Tag"
...
FONT 8, "MS Shell Dlg", 0, 0, 0x0
    LTEXT           "X Times",IDC_STATIC,148,50,24,8
```