### PR TITLE
Avoid crash on too few fields for lexer's keyword lists

### DIFF
--- a/src/StyleLexers/styleLexVHDL.c
+++ b/src/StyleLexers/styleLexVHDL.c
@@ -22,7 +22,7 @@ KEYWORDLIST KeyWords_VHDL = {
 "UX01 UX01Z X01 X01Z bit bit_vector boolean character delay_length file_open_kind file_open_status integer "
 "line natural positive real severity_level side signed std_logic std_logic_vector std_ulogic "
 "std_ulogic_vector string text time unsigned width",
-"", "", "" };
+"", "", "", "" };
 
 EDITLEXER lexVHDL = { 
 SCLEX_VHDL, IDS_LEX_VHDL, L"VHDL", L"vhdl; vhd", L"", 

--- a/src/Styles.c
+++ b/src/Styles.c
@@ -981,8 +981,17 @@ void Style_SetLexer(HWND hwnd, PEDITLEXER pLexNew)
 
 
   // Add KeyWord Lists
-  for (int i = 0; i < (KEYWORDSET_MAX + 1); i++) {
-    SciCall_SetKeywords(i, pLexNew->pKeyWords->pszKeyWords[i]);
+  for (int i = 0; i < (KEYWORDSET_MAX + 1); i++)
+  {
+    const char* pKeyWordList = pLexNew->pKeyWords->pszKeyWords[i];
+    assert(pKeyWordList != NULL);
+
+    if (pKeyWordList != NULL) {
+      SciCall_SetKeywords(i, pKeyWordList);
+    }
+    else {
+      SciCall_SetKeywords(i, "");
+    }
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
…  (crash of VHDL lexer)

@hpwamr : There wa an empty keyword list ("") missing for `VHDL` (`StyleLexers/styleLexVHDL.c`).
Maybe from the Keyword List refactoring.
Please check if the keywords still fit to the Type (compare to `Scintilla/lexers/LexVHDL.cxx`, lines 64-70)
If Notepad3 is compiled in Debug mode (instead of Release mode), you will be informed (debug assertion) if other lexers have a missing entry ...