### PR TITLE
ScintillaWin: Canceling behavior of Japanese IME

### DIFF
--- a/scintilla/win32/ScintillaWin.cxx
+++ b/scintilla/win32/ScintillaWin.cxx
@@ -1286,6 +1286,11 @@ sptr_t ScintillaWin::HandleCompositionInline(uptr_t, sptr_t lParam) {
 
 	view.imeCaretBlockOverride = false;
 
+	if (lParam & GCS_RESULTSTR) {
+		AddWString(imc.GetCompositionString(GCS_RESULTSTR), CharacterSource::imeResult);
+		initialCompose = true;
+	}
+
 	if (lParam & GCS_COMPSTR) {
 		const std::wstring wcs = imc.GetCompositionString(GCS_COMPSTR);
 		if (wcs.empty()) {
@@ -1331,8 +1336,6 @@ sptr_t ScintillaWin::HandleCompositionInline(uptr_t, sptr_t lParam) {
 		if (KoreanIME()) {
 			view.imeCaretBlockOverride = true;
 		}
-	} else if (lParam & GCS_RESULTSTR) {
-		AddWString(imc.GetCompositionString(GCS_RESULTSTR), CharacterSource::imeResult);
 	}
 	EnsureCaretVisible();
 	ShowCaretAtCurrentPosition();


### PR DESCRIPTION
Canceling behavior of Japanese IME via https://github.com/zufuliu/notepad2/commit/f75470d5be2dd27c8e05d87adf19fbf7197c87c0. 

Zufuliu fixed it. I want to report to Scinttila. But, Debugging Scintilla is difficult for me. However, this code fixes the behavior of the IME. If PL is not good, I will talk in the ISSUE.

Other languages are probably not affected. I tried it briefly.

Previous reports: https://github.com/rizonesoft/Notepad3/issues/632#issuecomment-416623554