### PR TITLE
Translation, and new fix of Scintilla beta

### DIFF
--- a/language/np3_ja_jp/strings_ja_jp.rc
+++ b/language/np3_ja_jp/strings_ja_jp.rc
@@ -278,7 +278,7 @@ Notepad3 \t[/?] [...[文字コード]] [...[改行コード]] [/e] [/g] [/m] [/l
 /n\t新しいウィンドウで開く (/ns ファイルは単一のインスタンス)\r\n\
 /r\tひとつウインドウを再利用 (/rs 同じく単一のインスタンス\r\n\
 /p\tウィンドウの位置とサイズを指定 [/p x,y,sizex,y[,max]] (/p0, /ps,\r\n\t/pf,l,t,r,b,m)\r\n\
-\tor /p <left>,<top>,<width>,<height>,<max>    [all integers]\r\n\
+\tor /p <left>,<top>,<width>,<height>,<max>    [すべて整数]\r\n\
 /t\tタイトルバーの文字列を指定 [/t text]\r\n\
 /i\tシステムトレイ内に起動\r\n\
 /o\t常に手前に表示\r\n\

--- a/scintilla/win32/ScintillaWin.cxx
+++ b/scintilla/win32/ScintillaWin.cxx
@@ -1319,7 +1319,6 @@ sptr_t ScintillaWin::HandleCompositionInline(uptr_t, sptr_t lParam) {
 
 	if (lParam & GCS_RESULTSTR) {
 		AddWString(imc.GetCompositionString(GCS_RESULTSTR), CharacterSource::imeResult);
-		initialCompose = true;
 	}
 
 	if (lParam & GCS_COMPSTR) {


### PR DESCRIPTION
Translation, and new fix of Scintilla beta: [Handle Japanese IME input when both GCS_COMPSTR and GCS_RESULTSTR set](https://sourceforge.net/p/scintilla/code/ci/92d3ec5798695db9da797028ea7b3cc701b3270d/). (Formal code of previous IME fix)