### PR TITLE
grepWinNP3 JP: typo

### DIFF
--- a/grepWinNP3/translationsNP3/日本語 （日本） [ja-JP].lang
+++ b/grepWinNP3/translationsNP3/日本語 （日本） [ja-JP].lang
@@ -458,7 +458,7 @@ msgstr "ファイルを UTF-8 として処理"
 
 #. Resource IDs: (1045)
 msgid "Visit Stefan Küng's website"
-msgstr "Stefan Küng のサイトを開く" 
+msgstr "Stefan Küng のサイトを開く"
 
 #. Resource IDs: (116)
 msgid "a regular expression used for searching. Press F1 for more info."


### PR DESCRIPTION
Delete single unnecessary space.