### PR TITLE
Use optimized Asian UI fonts for dialog boxes

### DIFF
--- a/grepWinNP3/default.build
+++ b/grepWinNP3/default.build
@@ -108,6 +108,11 @@
     <exec program="tools\restext.exe" >
       <arg value="extract" />
       <arg value="bin\release\grepWin.exe" />
+      <arg value="translations\Spanish Mexican.lang" />
+    </exec>
+    <exec program="tools\restext.exe" >
+      <arg value="extract" />
+      <arg value="bin\release\grepWin.exe" />
       <arg value="translations\Italian.lang" />
     </exec>
     <exec program="tools\restext.exe" >
@@ -164,6 +169,16 @@
       <arg value="extract" />
       <arg value="bin\release\grepWin.exe" />
       <arg value="translations\Swedish.lang" />
+    </exec>
+    <exec program="tools\restext.exe" >
+      <arg value="extract" />
+      <arg value="bin\release\grepWin.exe" />
+      <arg value="translations\Afrikaans.lang" />
+    </exec>
+    <exec program="tools\restext.exe" >
+      <arg value="extract" />
+      <arg value="bin\release\grepWin.exe" />
+      <arg value="translations\Korean.lang" />
     </exec>
   </target>
 

--- a/grepWinNP3/src/SearchDlg.h
+++ b/grepWinNP3/src/SearchDlg.h
@@ -127,7 +127,7 @@ protected:
     void                    UpdateInfoLabel();
     bool                    SaveSettings();
     void                    SaveWndPosition();
-    void                    formatDate(TCHAR date_native[], const FILETIME& filetime, bool force_short_fmt);
+    void                    formatDate(wchar_t date_native[], const FILETIME& filetime, bool force_short_fmt);
     int                     CheckRegex();
     bool                    MatchPath(LPCTSTR pathbuf);
     void                    AutoSizeAllColumns();

--- a/grepWinNP3/src/last/version.h
+++ b/grepWinNP3/src/last/version.h
@@ -6,13 +6,13 @@
 
 //#pragma message(__LOC__"Run the NAnt script to get proper version info")
 
-#define FILEVER         2, 1, 3, 24
-#define PRODUCTVER      2, 1, 3, 24
-#define STRFILEVER      "2.1.3.24\0"
-#define STRPRODUCTVER   "2.1.3.24\0"
+#define FILEVER         2, 1, 3, 25
+#define PRODUCTVER      2, 1, 3, 25
+#define STRFILEVER      "2.1.3.25\0"
+#define STRPRODUCTVER   "2.1.3.25\0"
 
 #define GREPWIN_VERMAJOR     2
 #define GREPWIN_VERMINOR     1
 #define GREPWIN_VERMICRO     3
-#define GREPWIN_VERBUILD     24
-#define GREPWIN_VERDATE      "2020-08-12"
+#define GREPWIN_VERBUILD     25
+#define GREPWIN_VERDATE      "2020-08-16"

--- a/src/Dialogs.h
+++ b/src/Dialogs.h
@@ -216,6 +216,7 @@ typedef struct {
 #pragma pack(pop)
 #endif
 
+bool GetLocaleDefaultUIFont(LANGID lang, LPWSTR lpFaceName, WORD* wSize);
 bool GetThemedDialogFont(LPWSTR lpFaceName, WORD* wSize);
 DLGTEMPLATE* LoadThemedDialogTemplate(LPCTSTR lpDialogTemplateID, HINSTANCE hInstance);
 #define ThemedDialogBox(hInstance,lpTemplate,hWndParent,lpDialogFunc) ThemedDialogBoxParam(hInstance,lpTemplate,hWndParent,lpDialogFunc,0)


### PR DESCRIPTION
@hpwamr :
If testing Dialogbox UI Layaut for Asian languages, please keep in mind, that not all font faces may be available on your system.

```
  switch (PRIMARYLANGID(lang)) {
    default:
    case LANG_ENGLISH:
      font   = L"Segoe UI";
      *wSize = 9;
      break;
    case LANG_CHINESE:
      font   = IsChineseTraditionalSubLang(subLang) ? L"Microsoft JhengHei UI" : L"Microsoft YaHei UI";
      *wSize = 9;
      break;
    case LANG_JAPANESE:
      font   = L"Meiryo UI";
      *wSize = 9;
      break;
    case LANG_KOREAN:
      font   = L"Malgun Gothic";
      *wSize = 9;
      break;
  }
```