### PR TITLE
 Missed to stage main changes in previous commit

### DIFF
--- a/src/Edit.c
+++ b/src/Edit.c
@@ -1745,7 +1745,7 @@ void EditURLEncode()
   WCHAR szTextW[INTERNET_MAX_URL_LENGTH+1];
   ptrdiff_t const cchTextW = MultiByteToWideChar(Encoding_SciCP, 0, pszText, (int)iSelSize, szTextW, INTERNET_MAX_URL_LENGTH);
   szTextW[cchTextW] = L'\0';
-  StrTrimW(szTextW, L" \r\n\t");
+  StrTrim(szTextW, L" \r\n\t");
 
   size_t const cchEscaped = iSelSize * 3 + 1;
   char* pszEscaped = (char*)AllocMem(cchEscaped, HEAP_ZERO_MEMORY);
@@ -8802,7 +8802,7 @@ void  EditGetBookmarkList(HWND hwnd, LPWSTR pszBookMarks, int cchLength)
     }
   } while (iLine >= 0);
 
-  StrTrimW(pszBookMarks, L";");
+  StrTrim(pszBookMarks, L";");
 }
 
 

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -286,7 +286,7 @@ inline bool TrimSpcA(LPSTR lpString) {
 
 inline bool TrimSpcW(LPWSTR lpString) {
   if (!lpString || !*lpString) { return false; }
-  return (bool)StrTrimW(lpString, L" \t\v");
+  return (bool)StrTrim(lpString, L" \t\v");
 };
 
 #if (defined(UNICODE) || defined(_UNICODE))


### PR DESCRIPTION
+ fix: TinyExpr: inline evaluation on active option only
+ fix: TinyExpr: allow rh equal and questionmark
+ fix: TinyExpr: newline after evaluation by '=<ENTER>'