### PR TITLE
Fix: disable Copy/Cut complete lines on partial multi-selection or rectangular-selection

### DIFF
--- a/src/Edit.c
+++ b/src/Edit.c
@@ -7875,7 +7875,10 @@ void EditBookMarkLineRange(HWND hwnd)
 //
 void EditDeleteMarkerInSelection()
 {
-  if (Sci_IsStreamSelection() && !SciCall_IsSelectionEmpty())
+  if (SciCall_IsSelectionEmpty()) {
+    SciCall_MarkerDelete(Sci_GetCurrentLineNumber(), -1);
+  }
+  else if (Sci_IsStreamSelection())
   {
     DocPos const posSelBeg = SciCall_GetSelectionStart();
     DocPos const posSelEnd = SciCall_GetSelectionEnd();


### PR DESCRIPTION
(Native Scintilla-based SCI_LINECUT not working on multi-selection  - better using explicit line marking for this use-case)