### PR TITLE
Fix Multi-Replace using RegExpr and Group-References

### DIFF
--- a/src/Edit.h
+++ b/src/Edit.h
@@ -87,7 +87,7 @@ void  EditJumpTo(DocLn iNewLine, DocPos iNewCol);
 void  EditSetSelectionEx(DocPos iAnchorPos, DocPos iCurrentPos, DocPos vSpcAnchor, DocPos vSpcCurrent);
 void  EditFixPositions();
 void  EditEnsureSelectionVisible();
-void	EditEnsureConsistentLineEndings(HWND hwnd);
+void  EditEnsureConsistentLineEndings(HWND hwnd);
 void  EditGetExcerpt(HWND hwnd,LPWSTR lpszExcerpt,DWORD cchExcerpt);
 
 HWND  EditFindReplaceDlg(HWND hwnd,LPCEDITFINDREPLACE lpefr,bool);


### PR DESCRIPTION
try to solve issue #3013.

@hpwamr : Please test also possible side-effects, e.g.:
- replacing "zero-length-matches" by e.g. line-begin (`^`) or line-end (`$`) pattern
  (using "`Overlapping search`" may produce unexpected results, e.g infinite loops, or replacing all:
  - replacing all '$' in "123456\r\n" with '7' (using option `Overlapping search`) will repeatedly append '7' at the end until NP3 
    crashes, cause next search starts right before line-end. Switch OFF `Overlapping search` to proceed beyond the line-end.
  - replacing all '^\d' in "123456\r\n" with ''(empty/nothing) (using option `Overlapping search`) will delete all numbers,
    because after deleting (=replacing with empty) one number at the  line-begin results in next number at line-begin.
    Switch OFF `Overlapping search` to proceed to next position (next line-begin).
- try using regex group definitions for replacement references too
- try using replacing all in selection too

Thanx, and best regards.
