### PR TITLE
Translation >Japanese : 2021/Feb LOCALE_DATEFMT

### DIFF
--- a/language/np3_ja_jp/strings_ja_jp.rc
+++ b/language/np3_ja_jp/strings_ja_jp.rc
@@ -251,7 +251,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_MUI_MENU_LANGUAGE   "言語(&L)"
-    IDS_USE_LOCALE_DATEFMT  "Language defines &Date Format"
+    IDS_USE_LOCALE_DATEFMT  "言語を日付の書式に反映(&D)"
     IDS_MUI_MENU_THEMES     "配色テーマ(&S)"
     IDM_THEMES_DEFAULT      "初期設定(&F)"
     IDM_THEMES_FILE_ITEM    "標準 (&S)"  // Keep blank space before (&S)


### PR DESCRIPTION
Hi!
It has already been translated in the original GrepWin.

There is an untranslated.
IDS_MUI_WRAPSEARCH_FWD seems not to be implemented yet:
265&266 IDS_MUI_WRAPSEARCH_FWD & IDS_MUI_WRAPSEARCH_BCK