### PR TITLE
Find/Repl dialog - refactoring and minor fixes

### DIFF
--- a/lexilla/Lexilla.vcxproj
+++ b/lexilla/Lexilla.vcxproj
@@ -201,6 +201,9 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <EnableEnhancedInstructionSet />
+      <OmitFramePointers />
+      <MinimalRebuild>false</MinimalRebuild>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -233,6 +236,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -294,6 +298,8 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <EnableEnhancedInstructionSet />
+      <MinimalRebuild>false</MinimalRebuild>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -325,6 +331,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/scintilla/Scintilla.vcxproj
+++ b/scintilla/Scintilla.vcxproj
@@ -184,6 +184,7 @@
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <FunctionLevelLinking>true</FunctionLevelLinking>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -209,6 +210,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <EnableEnhancedInstructionSet />
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Lib>
       <TargetMachine>MachineX64</TargetMachine>
@@ -241,6 +243,7 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -302,6 +305,7 @@
       <EnableEnhancedInstructionSet />
       <OmitFramePointers>true</OmitFramePointers>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Lib>
       <TargetMachine>

--- a/src/Dialogs.c
+++ b/src/Dialogs.c
@@ -4736,6 +4736,46 @@ void SetWindowReadingRTL(HWND hwnd, bool bRTL)
 
 //=============================================================================
 //
+//  A2W: Convert Dialog Item Text form Unicode to UTF-8 and vice versa
+//
+
+UINT ComboBox_GetTextLenth(HWND hDlg, int nIDDlgItem) {
+    return (UINT)ComboBox_GetTextLength(GetDlgItem(hDlg, nIDDlgItem));
+}
+
+UINT ComboBox_GetTextW2MB(HWND hDlg, int nIDDlgItem, LPSTR lpString, int nMaxCount) {
+    WCHAR wsz[FNDRPL_BUFFER] = { L'\0' };
+    HWND const hwndCtl = GetDlgItem(hDlg, nIDDlgItem);
+    UINT const uRet = (UINT)ComboBox_GetTextLength(hwndCtl);
+    int const idx = ComboBox_GetCurSel(hwndCtl);
+    if (-1 != idx) {
+        if (uRet < COUNTOF(wsz)) {
+            ComboBox_GetLBText(hwndCtl, ComboBox_GetCurSel(hwndCtl), wsz);
+        }
+    } else {
+        ComboBox_GetText(hwndCtl, wsz, COUNTOF(wsz));
+    }
+    ZeroMemory(lpString, nMaxCount);
+    WideCharToMultiByte(Encoding_SciCP, 0, wsz, -1, lpString, nMaxCount - 1, NULL, NULL);
+    return uRet;
+}
+
+void ComboBox_SetTextMB2W(HWND hDlg, int nIDDlgItem, LPCSTR lpString) {
+    WCHAR wsz[FNDRPL_BUFFER] = { L'\0' };
+    MultiByteToWideChar(Encoding_SciCP, 0, lpString, -1, wsz, (int)COUNTOF(wsz));
+    ComboBox_SetText(GetDlgItem(hDlg, nIDDlgItem), wsz);
+    //return SetDlgItemText(hDlg, nIDDlgItem, wsz);
+}
+
+LRESULT ComboBox_AddStringMB2W(HWND hwnd, LPCSTR lpString) {
+    WCHAR wsz[FNDRPL_BUFFER] = { L'\0' };
+    MultiByteToWideChar(Encoding_SciCP, 0, lpString, -1, wsz, (int)COUNTOF(wsz));
+    return SendMessageW(hwnd, CB_ADDSTRING, 0, (LPARAM)wsz);
+}
+
+
+//=============================================================================
+//
 //  GetCenterOfDlgInParent()
 //
 POINT GetCenterOfDlgInParent(const RECT* rcDlg, const RECT* rcParent)

--- a/src/Dialogs.h
+++ b/src/Dialogs.h
@@ -77,11 +77,18 @@ void AppendAdditionalTitleInfo(LPCWSTR lpszAddTitleInfo);
 void SetWindowTransparentMode(HWND hwnd, bool bTransparentMode, int iOpacityLevel);
 void SetWindowLayoutRTL(HWND hwnd, bool bRTL);
 void SetWindowReadingRTL(HWND hwnd, bool bRTL);
+
+UINT ComboBox_GetTextLenth(HWND hDlg, int nIDDlgItem);
+UINT ComboBox_GetTextW2MB(HWND hDlg, int nIDDlgItem, LPSTR lpString, int nMaxCount);
+void ComboBox_SetTextMB2W(HWND hDlg, int nIDDlgItem, LPCSTR lpString);
+LRESULT ComboBox_AddStringMB2W(HWND hwnd, LPCSTR lpString);
+
 POINT GetCenterOfDlgInParent(const RECT* rcDlg, const RECT* rcParent);
 HWND GetParentOrDesktop(HWND hDlg);
 void CenterDlgInParent(HWND hDlg, HWND hDlgParent);
 void GetDlgPos(HWND hDlg, LPINT xDlg, LPINT yDlg);
 void SetDlgPos(HWND hDlg, int xDlg, int yDlg);
+
 
 inline void InitWindowCommon(HWND hwnd, bool bSetExplorerTheme)
 {

--- a/src/Helpers.c
+++ b/src/Helpers.c
@@ -1561,34 +1561,6 @@ bool SetDlgItemIntEx(HWND hwnd,int nIdItem,UINT uValue)
 
 //=============================================================================
 //
-//  A2W: Convert Dialog Item Text form Unicode to UTF-8 and vice versa
-//
-UINT GetDlgItemTextW2MB(HWND hDlg, int nIDDlgItem, LPSTR lpString, int nMaxCount)
-{
-    WCHAR wsz[FNDRPL_BUFFER] = { L'\0' };
-    UINT const uRet = GetDlgItemTextW(hDlg, nIDDlgItem, wsz, COUNTOF(wsz));
-    ZeroMemory(lpString, nMaxCount);
-    WideCharToMultiByte(Encoding_SciCP, 0, wsz, -1, lpString, nMaxCount - 1, NULL, NULL);
-    return uRet;
-}
-
-UINT SetDlgItemTextMB2W(HWND hDlg, int nIDDlgItem, LPCSTR lpString)
-{
-    WCHAR wsz[FNDRPL_BUFFER] = { L'\0' };
-    MultiByteToWideChar(Encoding_SciCP, 0, lpString, -1, wsz, (int)COUNTOF(wsz));
-    return SetDlgItemText(hDlg, nIDDlgItem, wsz);
-}
-
-LRESULT ComboBox_AddStringMB2W(HWND hwnd, LPCSTR lpString)
-{
-    WCHAR wsz[FNDRPL_BUFFER] = { L'\0' };
-    MultiByteToWideChar(Encoding_SciCP, 0, lpString, -1, wsz, (int)COUNTOF(wsz));
-    return SendMessageW(hwnd, CB_ADDSTRING, 0, (LPARAM)wsz);
-}
-
-
-//=============================================================================
-//
 //  CodePageFromCharSet()
 //
 UINT CodePageFromCharSet(const UINT uCharSet)

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -448,11 +448,6 @@ void PathFixBackslashes(LPWSTR lpsz);
 size_t FormatNumberStr(LPWSTR lpNumberStr, size_t cch, int fixedWidth);
 bool SetDlgItemIntEx(HWND hwnd,int nIdItem,UINT uValue);
 
-UINT GetDlgItemTextW2MB(HWND hDlg, int nIDDlgItem, LPSTR lpString, int nMaxCount);
-UINT SetDlgItemTextMB2W(HWND hDlg, int nIDDlgItem, LPCSTR lpString);
-LRESULT ComboBox_AddStringMB2W(HWND hwnd, LPCSTR lpString);
-
-
 ///////////////////////////////////////////////////////////////////////
 ///  UINT  GDI CHARSET values  ==  Scintilla's  SC_CHARSET_XXX values
 ///////////////////////////////////////////////////////////////////////

--- a/src/Notepad3.vcxproj
+++ b/src/Notepad3.vcxproj
@@ -165,7 +165,10 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <CompileAsWinRT>false</CompileAsWinRT>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <ExceptionHandling>Async</ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <OmitFramePointers />
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ntdll.lib;comctl32.lib;imm32.lib;shlwapi.lib;muiload.lib;scintilla.lib;lexilla.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -231,8 +234,12 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <CompileAsWinRT>false</CompileAsWinRT>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <ExceptionHandling>Async</ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <EnableEnhancedInstructionSet />
+      <OmitFramePointers>
+      </OmitFramePointers>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ntdll.lib;comctl32.lib;imm32.lib;shlwapi.lib;muiload.lib;scintilla.lib;lexilla.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -306,6 +313,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ntdll.lib;comctl32.lib;imm32.lib;shlwapi.lib;muiload.lib;scintilla.lib;lexilla.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -461,6 +469,7 @@
       <EnableEnhancedInstructionSet />
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WholeProgramOptimization>true</WholeProgramOptimization>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ntdll.lib;comctl32.lib;imm32.lib;shlwapi.lib;muiload.lib;scintilla.lib;lexilla.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
ref. issue #3107

@hpwamr : Please test thoroughly, cause of changes at the core of the Find/Repl dialog.
Major Points for F/R-Dialog here are:
- Mark Occurrences On/Off 
- Focused View toggle adding marker
- Searching while typing / selecting older pattern
- Switching to editor, edit, move caret and back to F/R-Dialog (re-activation)
- Cooperation of Dialog with (Ctrl+F3 searching with and w/o F/R-Dialog)
- maybe more I forgot here ... 😅 