### PR TITLE
Change simple Line Comment Toggle behavior & move menu entry

### DIFF
--- a/language/np3_en_us/menu_en_us.rc
+++ b/language/np3_en_us/menu_en_us.rc
@@ -207,9 +207,9 @@ BEGIN
         BEGIN
             MENUITEM "&Indent",                           IDM_EDIT_INDENT
             MENUITEM "&Unindent",                         IDM_EDIT_UNINDENT
-            MENUITEM SEPARATOR
-            MENUITEM "Jump to Sele&ction Start\tCtrl+,",  CMD_JUMP2SELSTART
-            MENUITEM "Jump to Selectio&n End\tCtrl+.",    CMD_JUMP2SELEND
+            MENUITEM "Line &Comment (Toggle)\tCtrl+Q",    IDM_EDIT_LINECOMMENT
+            MENUITEM "Enable Line Comment &Block Edit",   IDM_VIEW_EDIT_LINECOMMENT
+            MENUITEM "St&ream Comment\tCtrl+Shift+Q",     IDM_EDIT_STREAMCOMMENT
             MENUITEM SEPARATOR
             POPUP "&Enclose Selection"
             BEGIN
@@ -235,6 +235,9 @@ BEGIN
             MENUITEM "&Modify Lines...\tAlt+M",           IDM_EDIT_MODIFYLINES
             MENUITEM "&Align Lines...\tAlt+J",            IDM_EDIT_ALIGN
             MENUITEM "&Sort Lines...\tAlt+O",             IDM_EDIT_SORTLINES
+            MENUITEM SEPARATOR
+            MENUITEM "Jump to Sele&ction Start\tCtrl+,",  CMD_JUMP2SELSTART
+            MENUITEM "Jump to Selectio&n End\tCtrl+.",    CMD_JUMP2SELEND
         END
         POPUP "Con&vert"
         BEGIN
@@ -269,9 +272,6 @@ BEGIN
             MENUITEM "Time/Date (&Long Form)\tCtrl+Shift+F5", IDM_EDIT_INSERT_LONGDATE
             MENUITEM "Current &Timestamp",                    CMD_INSERT_TIMESTAMP
             MENUITEM "&Update Timestamps\tShift+F5",          CMD_UPDATE_TIMESTAMPS
-            MENUITEM SEPARATOR
-            MENUITEM "Line &Comment (Toggle)\tCtrl+Q",        IDM_EDIT_LINECOMMENT
-            MENUITEM "St&ream Comment\tCtrl+Shift+Q",         IDM_EDIT_STREAMCOMMENT
         END
         POPUP "&Miscellaneous"
         BEGIN
@@ -444,7 +444,6 @@ BEGIN
         MENUITEM "A&uto Complete Words",                     IDM_VIEW_AUTOCOMPLETEWORDS
         MENUITEM "Auto Complete Lexer-&Key-Words",           IDM_VIEW_AUTOCLEXKEYWORDS
         MENUITEM "Accelerated Word Navi&gation\tCtrl+Alt+A", IDM_VIEW_ACCELWORDNAV
-        MENUITEM "Enable Line Comment &Block Edit",          IDM_VIEW_EDIT_LINECOMMENT
         MENUITEM SEPARATOR
         MENUITEM "Single &File Instance",                    IDM_VIEW_SINGLEFILEINSTANCE
         MENUITEM "File &Change Notification...\tAlt+F5",     IDM_VIEW_CHANGENOTIFY

--- a/src/Edit.c
+++ b/src/Edit.c
@@ -3330,11 +3330,17 @@ void EditToggleLineCommentsSimple(HWND hwnd, LPCWSTR pwszComment, bool bInsertAt
     DocPos const saveTargetBeg = SciCall_GetTargetStart();
     DocPos const saveTargetEnd = SciCall_GetTargetEnd();
 
-    int iAction = 0;
-
     _BEGIN_UNDO_ACTION_;
 
+    int iAction = 0;
+    bool const bKeepActionOf1stLine = false;
+
     for (DocLn iLine = iLineStart; iLine <= iLineEnd; ++iLine) {
+
+        if (!bKeepActionOf1stLine) {
+            iAction = 0;
+        }
+
         DocPos const iIndentPos = SciCall_GetLineIndentPosition(iLine);
 
         if (iIndentPos == SciCall_GetLineEndPosition(iLine)) {
@@ -3352,7 +3358,7 @@ void EditToggleLineCommentsSimple(HWND hwnd, LPCWSTR pwszComment, bool bInsertAt
                 iAction = 2;
             case 2:
                 SciCall_SetTargetRange(iIndentPos, iSelPos);
-                SciCall_ReplaceTarget(0, "");
+                SciCall_ReplaceTarget(-1, "");
                 iSelEndOffset -= cchComment;
                 if (iLine == iLineStart) {
                     iSelStartOffset = (iSelStart == SciCall_PositionFromLine(iLine)) ? 0 : (0 - cchComment);
@@ -3369,7 +3375,7 @@ void EditToggleLineCommentsSimple(HWND hwnd, LPCWSTR pwszComment, bool bInsertAt
                 iAction = 2;
             case 2:
                 SciCall_SetTargetRange(iIndentPos, iSelPos);
-                SciCall_ReplaceTarget(0, "");
+                SciCall_ReplaceTarget(-1, "");
                 iSelEndOffset -= cchPrefix;
                 if (iLine == iLineStart) {
                     iSelStartOffset = (iSelStart == SciCall_PositionFromLine(iLine)) ? 0 : (0 - cchPrefix);
@@ -3462,8 +3468,6 @@ void EditToggleLineCommentsExtended(HWND hwnd, LPCWSTR pwszComment, bool bInsert
     DocPos const saveTargetBeg = SciCall_GetTargetStart();
     DocPos const saveTargetEnd = SciCall_GetTargetEnd();
 
-    int iAction = 0;
-
     UT_icd docpos_icd = { sizeof(DocPos), NULL, NULL, NULL };
     UT_array* sel_positions = NULL;
     utarray_new(sel_positions, &docpos_icd);
@@ -3471,7 +3475,15 @@ void EditToggleLineCommentsExtended(HWND hwnd, LPCWSTR pwszComment, bool bInsert
 
     _BEGIN_UNDO_ACTION_;
 
+    int iAction = 0;
+    bool const bKeepActionOf1stLine = true;
+
     for (DocLn iLine = iLineStart; iLine <= iLineEnd; ++iLine) {
+
+        if (!bKeepActionOf1stLine) {
+            iAction = 0;
+        }
+
         DocPos const iIndentPos = SciCall_GetLineIndentPosition(iLine);
 
         if (iIndentPos == SciCall_GetLineEndPosition(iLine)) {
@@ -3489,7 +3501,7 @@ void EditToggleLineCommentsExtended(HWND hwnd, LPCWSTR pwszComment, bool bInsert
                 iAction = 2;
             case 2:
                 SciCall_SetTargetRange(iIndentPos, iSelPos);
-                SciCall_ReplaceTarget(0, "");
+                SciCall_ReplaceTarget(-1, "");
                 utarray_push_back(sel_positions, &iIndentPos);
                 break;
             case 1:


### PR DESCRIPTION
+ chg: Menu (en-US) move line/stream comment items to Edit->Selection top
+ fix: JSON Lexer has comments enabled now
+ chg: Simple Line Comment Toggle handles each line separately
           (Line Edit after toggle will still set mode of 1st line == former behavior)