### PR TITLE
Workaround Scintilla text-rendering bug

### DIFF
--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -1885,7 +1885,11 @@ static void  _InitializeSciEditCtrl(HWND hwndEditCtrl)
     SciCall_SetPhasesDraw(SC_PHASES_MULTIPLE);
     //~SciCall_SetLayoutCache(SC_CACHE_DOCUMENT); // memory consumption !
     SciCall_SetLayoutCache(SC_CACHE_PAGE);
-    SciCall_SetPositionCache(2048);  // default = 1024
+
+    // Idle Styling (very large text)
+    //~~~SciCall_SetIdleStyling(SC_IDLESTYLING_NONE); // needed for focused view
+    //~~~SciCall_SetIdleStyling(SC_IDLESTYLING_AFTERVISIBLE);
+    SciCall_SetIdleStyling(SC_IDLESTYLING_ALL);
 
     // The possible notification types are the same as the modificationType bit flags used by SCN_MODIFIED:
     // SC_MOD_INSERTTEXT, SC_MOD_DELETETEXT, SC_MOD_CHANGESTYLE, SC_MOD_CHANGEFOLD, SC_PERFORMED_USER,
@@ -1902,9 +1906,15 @@ static void  _InitializeSciEditCtrl(HWND hwndEditCtrl)
     SciCall_SetModEventMask(evtMask1 | evtMask2);
     SciCall_SetCommandEvents(false); // speedup folding
 
+    SciCall_StyleSetCharacterSet(SC_CHARSET_DEFAULT);
     SciCall_SetCodePage(SC_CP_UTF8); // fixed internal UTF-8 (Sci:default)
 
     SciCall_SetMargins(NUMBER_OF_MARGINS);
+    SciCall_SetMarginTypeN(MARGIN_SCI_LINENUM, SC_MARGIN_NUMBER);
+    SciCall_SetMarginTypeN(MARGIN_SCI_BOOKMRK, SC_MARGIN_SYMBOL);
+    SciCall_SetMarginTypeN(MARGIN_SCI_FOLDING, SC_MARGIN_COLOUR);
+    SciCall_SetMarginMaskN(MARGIN_SCI_FOLDING, SC_MASK_FOLDERS);
+
     SciCall_SetEOLMode(Settings.DefaultEOLMode);
     SciCall_SetPasteConvertEndings(true);
     SciCall_UsePopUp(SC_POPUP_TEXT);
@@ -1920,11 +1930,6 @@ static void  _InitializeSciEditCtrl(HWND hwndEditCtrl)
 
     SciCall_SetAdditionalCaretsBlink(true);
     SciCall_SetAdditionalCaretsVisible(true);
-
-    // Idle Styling (very large text)
-    //~~~SciCall_SetIdleStyling(SC_IDLESTYLING_AFTERVISIBLE);
-    //~~~SciCall_SetIdleStyling(SC_IDLESTYLING_ALL);
-    SciCall_SetIdleStyling(SC_IDLESTYLING_NONE); // needed for focused view
 
     // assign command keys
     SciCall_AssignCmdKey(SCK_NEXT + (SCMOD_CTRL << 16), SCI_PARADOWN);
@@ -9233,7 +9238,8 @@ void UpdateMarginWidth(const bool bForce)
             SciCall_SetMarginWidthN(MARGIN_SCI_LINENUM, iLineMarginWidthFit);
         }
     } else {
-        SciCall_SetMarginWidthN(MARGIN_SCI_LINENUM, 0);
+        // TODO: SCI Bug if set to 0 (=invisible), workaround use 1px 
+        SciCall_SetMarginWidthN(MARGIN_SCI_LINENUM, 1);
     }
     Style_SetBookmark(Globals.hwndEdit, Settings.ShowBookmarkMargin);
     Style_SetFolding(Globals.hwndEdit, (FocusedView.CodeFoldingAvailable && FocusedView.ShowCodeFolding));

--- a/src/SciCall.h
+++ b/src/SciCall.h
@@ -164,6 +164,7 @@ DeclareSciCallV1(SetModEventMask, SETMODEVENTMASK, int, mask);
 DeclareSciCallV1(SetCommandEvents, SETCOMMANDEVENTS, bool, flag);
 // Code Page
 DeclareSciCallV1(SetCodePage, SETCODEPAGE, int, cp);
+DeclareSciCallV1(StyleSetCharacterSet, STYLESETCHARACTERSET, int, cs);
 // Divers
 DeclareSciCallV1(SetMargins, SETMARGINS, int, nmarg);
 DeclareSciCallV1(SetPasteConvertEndings, SETPASTECONVERTENDINGS, bool, flag);

--- a/src/Styles.c
+++ b/src/Styles.c
@@ -1501,8 +1501,8 @@ void Style_SetLexer(HWND hwnd, PEDITLEXER pLexNew)
     SciCall_SetLayoutCache(SC_CACHE_PAGE); //~SC_CACHE_DOCUMENT ~ memory consumption !
     SciCall_SetPositionCache(SciCall_GetPositionCache()); // clear - default=1024
 
-    SciCall_StartStyling(0);
     SciCall_SetIdleStyling(SC_IDLESTYLING_ALL);
+    SciCall_StartStyling(0);
 
     // apply lexer styles
     if (Flags.bHugeFileLoadState) {
@@ -1848,6 +1848,12 @@ void Style_SetMargin(HWND hwnd, LPCWSTR lpszStyle) // iStyle = STYLE_LINENUMBER
 {
     Style_SetStyles(hwnd, STYLE_LINENUMBER, lpszStyle, false); // line numbers
 
+    COLORREF clrFore;
+    if (!Style_StrGetColor(lpszStyle, FOREGROUND_LAYER, &clrFore, true)) {
+        clrFore = GetModeTextColor(UseDarkMode());
+    }
+    SciCall_StyleSetFore(STYLE_LINENUMBER, clrFore);
+
     COLORREF clrBack;
     if (!Style_StrGetColor(lpszStyle, BACKGROUND_LAYER, &clrBack, false)) {
         clrBack = GetModeBtnfaceColor(UseDarkMode());
@@ -1856,9 +1862,6 @@ void Style_SetMargin(HWND hwnd, LPCWSTR lpszStyle) // iStyle = STYLE_LINENUMBER
     SciCall_SetMarginBackN(MARGIN_SCI_LINENUM, clrBack);
     SciCall_SetMarginSensitiveN(MARGIN_SCI_LINENUM, false); /// false: allow selection drag
     //~SciCall_SetMarginBackN(MARGIN_SCI_LINENUM, clrBack);
-
-    COLORREF clrFore;
-    Style_StrGetColor(lpszStyle, FOREGROUND_LAYER, &clrFore, true);
 
     // CallTips
     SciCall_CallTipSetFore(clrFore);
@@ -1920,8 +1923,6 @@ void Style_SetMargin(HWND hwnd, LPCWSTR lpszStyle) // iStyle = STYLE_LINENUMBER
     const WCHAR* wchHighlightStyleStrg = GetCurrentStdLexer()->Styles[STY_SEL_TXT].szValue;
     Style_StrGetColor(wchHighlightStyleStrg, FOREGROUND_LAYER, &fldHiLight, true);
 
-    SciCall_SetMarginTypeN(MARGIN_SCI_FOLDING, SC_MARGIN_COLOUR);
-    SciCall_SetMarginMaskN(MARGIN_SCI_FOLDING, SC_MASK_FOLDERS);
     SciCall_SetMarginBackN(MARGIN_SCI_FOLDING, clrBack);
     SciCall_SetMarginSensitiveN(MARGIN_SCI_FOLDING, true);
 


### PR DESCRIPTION
... if line-number marginwidth set to 0 (so use 1 instead)

ref. issue #3337