### PR TITLE
Fix grepWinNP3: fix compiler warning Release Win32

### DIFF
--- a/grepWinNP3/grepWinNP3.vcxproj
+++ b/grepWinNP3/grepWinNP3.vcxproj
@@ -142,6 +142,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level4</WarningLevel>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -167,6 +168,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level4</WarningLevel>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -197,6 +199,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -226,6 +229,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level4</WarningLevel>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -259,6 +263,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -286,6 +291,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level4</WarningLevel>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -310,7 +316,6 @@
     <ClCompile Include="sktoolslib_mod\BaseWindow.cpp" />
     <ClCompile Include="sktoolslib_mod\BrowseFolder.cpp" />
     <ClCompile Include="sktoolslib_mod\CmdLineParser.cpp" />
-    <ClCompile Include="sktoolslib_mod\codecvt.cpp" />
     <ClCompile Include="sktoolslib_mod\DarkModeHelper.cpp" />
     <ClCompile Include="sktoolslib_mod\DebugOutput.cpp" />
     <ClCompile Include="sktoolslib_mod\DirFileEnum.cpp" />
@@ -358,7 +363,6 @@
     <ClInclude Include="sktoolslib_mod\BaseWindow.h" />
     <ClInclude Include="sktoolslib_mod\BrowseFolder.h" />
     <ClInclude Include="sktoolslib_mod\CmdLineParser.h" />
-    <ClInclude Include="sktoolslib_mod\codecvt.h" />
     <ClInclude Include="sktoolslib_mod\DarkModeHelper.h" />
     <ClInclude Include="sktoolslib_mod\DebugOutput.h" />
     <ClInclude Include="sktoolslib_mod\DirFileEnum.h" />

--- a/grepWinNP3/grepWinNP3.vcxproj.filters
+++ b/grepWinNP3/grepWinNP3.vcxproj.filters
@@ -72,12 +72,6 @@
     <ClCompile Include="src\Theme.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="sktoolslib_mod\AeroControls.cpp">
-      <Filter>sktoolslib_mod</Filter>
-    </ClCompile>
-    <ClCompile Include="sktoolslib_mod\AeroGlass.cpp">
-      <Filter>sktoolslib_mod</Filter>
-    </ClCompile>
     <ClCompile Include="sktoolslib_mod\AutoComplete.cpp">
       <Filter>sktoolslib_mod</Filter>
     </ClCompile>
@@ -91,9 +85,6 @@
       <Filter>sktoolslib_mod</Filter>
     </ClCompile>
     <ClCompile Include="sktoolslib_mod\CmdLineParser.cpp">
-      <Filter>sktoolslib_mod</Filter>
-    </ClCompile>
-    <ClCompile Include="sktoolslib_mod\codecvt.cpp">
       <Filter>sktoolslib_mod</Filter>
     </ClCompile>
     <ClCompile Include="sktoolslib_mod\DebugOutput.cpp">
@@ -159,6 +150,12 @@
     <ClCompile Include="sktoolslib_mod\hyperlink.cpp">
       <Filter>sktoolslib_mod</Filter>
     </ClCompile>
+    <ClCompile Include="sktoolslib_mod\AeroControls.cpp">
+      <Filter>sktoolslib_mod</Filter>
+    </ClCompile>
+    <ClCompile Include="sktoolslib_mod\AeroGlass.cpp">
+      <Filter>sktoolslib_mod</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\AboutDlg.h">
@@ -212,12 +209,6 @@
     <ClInclude Include="src\Theme.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="sktoolslib_mod\AeroControls.h">
-      <Filter>sktoolslib_mod</Filter>
-    </ClInclude>
-    <ClInclude Include="sktoolslib_mod\AeroGlass.h">
-      <Filter>sktoolslib_mod</Filter>
-    </ClInclude>
     <ClInclude Include="sktoolslib_mod\AutoComplete.h">
       <Filter>sktoolslib_mod</Filter>
     </ClInclude>
@@ -231,9 +222,6 @@
       <Filter>sktoolslib_mod</Filter>
     </ClInclude>
     <ClInclude Include="sktoolslib_mod\CmdLineParser.h">
-      <Filter>sktoolslib_mod</Filter>
-    </ClInclude>
-    <ClInclude Include="sktoolslib_mod\codecvt.h">
       <Filter>sktoolslib_mod</Filter>
     </ClInclude>
     <ClInclude Include="sktoolslib_mod\DebugOutput.h">
@@ -312,6 +300,12 @@
       <Filter>sktoolslib_mod</Filter>
     </ClInclude>
     <ClInclude Include="sktoolslib_mod\hyperlink.h">
+      <Filter>sktoolslib_mod</Filter>
+    </ClInclude>
+    <ClInclude Include="sktoolslib_mod\AeroControls.h">
+      <Filter>sktoolslib_mod</Filter>
+    </ClInclude>
+    <ClInclude Include="sktoolslib_mod\AeroGlass.h">
       <Filter>sktoolslib_mod</Filter>
     </ClInclude>
   </ItemGroup>

--- a/grepWinNP3/src/SearchDlg.cpp
+++ b/grepWinNP3/src/SearchDlg.cpp
@@ -1872,7 +1872,7 @@ bool CSearchDlg::AddFoundEntry(const CSearchInfo* pInfo, bool bOnlyListControl)
     {
         HWND hListControl = GetDlgItem(*this, IDC_RESULTLIST);
         bool fileList     = (IsDlgButtonChecked(*this, IDC_RESULTFILES) == BST_CHECKED);
-        auto count        = ListView_GetItemCount(hListControl);
+        auto count        = static_cast<size_t>(ListView_GetItemCount(hListControl));
         if (count != (fileList ? m_items.size() : m_listItems.size()))
             ListView_SetItemCountEx(hListControl, fileList ? m_items.size() : m_listItems.size(), LVSICF_NOINVALIDATEALL | LVSICF_NOSCROLL);
     }

--- a/lexilla/Lexilla.vcxproj
+++ b/lexilla/Lexilla.vcxproj
@@ -220,7 +220,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>
       </SDLCheck>
       <PreprocessorDefinitions>SCI_LEXER;_CRT_SECURE_NO_WARNINGS;STATIC_BUILD;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -236,6 +236,7 @@
       <OmitFramePointers />
       <MinimalRebuild>false</MinimalRebuild>
       <SmallerTypeCheck>false</SmallerTypeCheck>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -247,7 +248,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>
@@ -269,6 +270,7 @@
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <MinimalRebuild>false</MinimalRebuild>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -285,7 +287,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_Dbg|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>
@@ -303,6 +305,7 @@
       </EnableEnhancedInstructionSet>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -317,7 +320,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>
       </SDLCheck>
       <PreprocessorDefinitions>SCI_LEXER;_CRT_SECURE_NO_WARNINGS;STATIC_BUILD;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -332,6 +335,7 @@
       <EnableEnhancedInstructionSet />
       <MinimalRebuild>false</MinimalRebuild>
       <SmallerTypeCheck>false</SmallerTypeCheck>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -343,7 +347,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>
@@ -364,6 +368,7 @@
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <MinimalRebuild>false</MinimalRebuild>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -380,7 +385,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_Dbg|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>
@@ -397,6 +402,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <EnableEnhancedInstructionSet />
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/lexilla/lexers_x/LexCSV.cxx
+++ b/lexilla/lexers_x/LexCSV.cxx
@@ -252,7 +252,7 @@ constexpr int GetStateByColumn(const int col) noexcept
     case 9:
         return SCE_CSV_COLUMN_9;
     default:
-        return SCE_CSV_COLUMN_0;
+        break;
     }
     return SCE_CSV_COLUMN_0;
 }
@@ -410,7 +410,7 @@ void SCI_METHOD LexerCSV::Lex(Sci_PositionU startPos, Sci_Position length, int i
 
 
 
-void SCI_METHOD LexerCSV::Fold(Sci_PositionU startPos, Sci_Position length, int, IDocument* pAccess)
+void SCI_METHOD LexerCSV::Fold(Sci_PositionU /*startPos*/, Sci_Position /*length*/, int, IDocument* /*pAccess*/)
 {
     return;
 }

--- a/lexilla/lexers_x/LexTOML.cxx
+++ b/lexilla/lexers_x/LexTOML.cxx
@@ -710,7 +710,7 @@ void SCI_METHOD LexerTOML::Lex(Sci_PositionU startPos, Sci_Position length, int 
             }
             else if (sc.ch == '}')
             {
-                auto p = static_cast<Sci_Position>(sc.currentPos);
+                //auto p = static_cast<Sci_Position>(sc.currentPos);
                 if (!_isQuoted(inSQuotedKey, inDQuotedKey))
                 {
                     if (bInInlBracket)
@@ -725,7 +725,7 @@ void SCI_METHOD LexerTOML::Lex(Sci_PositionU startPos, Sci_Position length, int 
             }
             else if (sc.ch == '{')
             {
-                auto p = static_cast<Sci_Position>(sc.currentPos);
+                //auto p = static_cast<Sci_Position>(sc.currentPos);
                 if (!_isQuoted(inSQuotedKey, inDQuotedKey))
                 {
                     if (bInInlBracket)

--- a/lexilla/lexers_x/LexerUtils.h
+++ b/lexilla/lexers_x/LexerUtils.h
@@ -110,7 +110,7 @@ namespace Scintilla {
         if (!ignoreCurrent && !IsWhiteSpace(sc.ch)) {
             return sc.ch;
         }
-        if (sc.currentPos + 1 == sc.lineStartNext) {
+        if (sc.currentPos + 1 == static_cast<Sci_PositionU>(sc.lineStartNext)) {
             return '\0';
         }
         if (!IsWhiteSpace(sc.chNext)) {

--- a/scintilla/Scintilla.vcxproj
+++ b/scintilla/Scintilla.vcxproj
@@ -175,7 +175,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>_WIN32_WINNT=0x601;WINVER=0x601;NTDDI_VERSION=0x06010000;_SCL_SECURE_NO_WARNINGS;NP3;NO_CXX11_REGEX;SCI_OWNREGEX;SCI_EMPTYCATALOGUE;ONIG_STATIC;USE_POSIX_API;USE_BINARY_COMPATIBLE_POSIX_API;WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;USE_D2D;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SmallerTypeCheck>false</SmallerTypeCheck>
       <OmitFramePointers />
       <StringPooling>true</StringPooling>
@@ -185,6 +185,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <MinimalRebuild>false</MinimalRebuild>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -203,7 +204,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>_WIN32_WINNT=0x601;WINVER=0x601;NTDDI_VERSION=0x06010000;_SCL_SECURE_NO_WARNINGS;NP3;NO_CXX11_REGEX;SCI_OWNREGEX;SCI_EMPTYCATALOGUE;ONIG_STATIC;USE_POSIX_API;USE_BINARY_COMPATIBLE_POSIX_API;_WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;USE_D2D;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SmallerTypeCheck>false</SmallerTypeCheck>
       <StringPooling>true</StringPooling>
       <FloatingPointModel>Precise</FloatingPointModel>
@@ -211,6 +212,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <EnableEnhancedInstructionSet />
       <MinimalRebuild>false</MinimalRebuild>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Lib>
       <TargetMachine>MachineX64</TargetMachine>
@@ -231,7 +233,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>_WIN32_WINNT=0x601;WINVER=0x601;NTDDI_VERSION=0x06010000;_SCL_SECURE_NO_WARNINGS;NP3;NO_CXX11_REGEX;SCI_OWNREGEX;SCI_EMPTYCATALOGUE;ONIG_STATIC;USE_POSIX_API;USE_BINARY_COMPATIBLE_POSIX_API;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;USE_D2D;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <OmitFramePointers>true</OmitFramePointers>
       <FloatingPointModel>Precise</FloatingPointModel>
@@ -244,6 +246,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <MinimalRebuild>false</MinimalRebuild>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -264,7 +267,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>_WIN32_WINNT=0x601;WINVER=0x601;NTDDI_VERSION=0x06010000;_SCL_SECURE_NO_WARNINGS;NP3;NO_CXX11_REGEX;SCI_OWNREGEX;SCI_EMPTYCATALOGUE;ONIG_STATIC;USE_POSIX_API;USE_BINARY_COMPATIBLE_POSIX_API;WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;USE_D2D;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <OmitFramePointers>
       </OmitFramePointers>
@@ -274,6 +277,7 @@
       <StringPooling>true</StringPooling>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
       <IntrinsicFunctions>false</IntrinsicFunctions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
@@ -292,7 +296,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>_WIN32_WINNT=0x601;WINVER=0x601;NTDDI_VERSION=0x06010000;_SCL_SECURE_NO_WARNINGS;NP3;NO_CXX11_REGEX;SCI_OWNREGEX;SCI_EMPTYCATALOGUE;ONIG_STATIC;USE_POSIX_API;USE_BINARY_COMPATIBLE_POSIX_API;SCI_LEXER;_WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;STATIC_BUILD;USE_D2D;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -306,6 +310,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <MinimalRebuild>false</MinimalRebuild>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Lib>
       <TargetMachine>
@@ -325,7 +330,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>_WIN32_WINNT=0x601;WINVER=0x601;NTDDI_VERSION=0x06010000;_SCL_SECURE_NO_WARNINGS;NP3;NO_CXX11_REGEX;SCI_OWNREGEX;SCI_EMPTYCATALOGUE;ONIG_STATIC;USE_POSIX_API;USE_BINARY_COMPATIBLE_POSIX_API;SCI_LEXER;_WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;STATIC_BUILD;USE_D2D;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -334,6 +339,7 @@
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <EnableEnhancedInstructionSet />
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Lib>
       <TargetMachine>MachineX64</TargetMachine>

--- a/scintilla/oniguruma/scintilla/OnigurumaRegExEngine.cxx
+++ b/scintilla/oniguruma/scintilla/OnigurumaRegExEngine.cxx
@@ -69,7 +69,7 @@ static OnigEncoding s_UsedEncodingsTypes[] = { ONIG_ENCODING_UTF8, ONIG_ENCODING
 // ------------------------------------
 // --- Onigmo Engine Simple Options ---
 // ------------------------------------
-static void SetSimpleOptions(OnigOptionType& onigOptions, EOLmode eolMode,
+static void SetSimpleOptions(OnigOptionType& onigOptions, EOLmode /*eolMode*/,
   const bool caseSensitive, const bool forwardSearch, const int searchFlags = 0)
 {
   // fixed options
@@ -126,7 +126,7 @@ class OnigurumaRegExEngine : public RegexSearchBase
 {
 public:
 
-  explicit OnigurumaRegExEngine(CharClassify* charClassTable)
+  explicit OnigurumaRegExEngine(CharClassify* /*charClassTable*/)
     : m_OnigSyntax(*ONIG_SYNTAX_DEFAULT)
     , m_CmplOptions(ONIG_OPTION_DEFAULT)
     , m_RegExpr(nullptr)
@@ -505,7 +505,7 @@ void OnigurumaRegExEngine::regexFindAndReplace(std::string& inputStr_inout, cons
 
 
 
-std::string& OnigurumaRegExEngine::translateRegExpr(std::string& regExprStr, bool wholeWord, bool wordStart, int eolMode, OnigOptionType& rxOptions)
+std::string& OnigurumaRegExEngine::translateRegExpr(std::string& regExprStr, bool wholeWord, bool wordStart, int eolMode, OnigOptionType& /*rxOptions*/)
 {
   std::string	tmpStr;
   bool bUseTmpStrg = false;

--- a/scintilla/oniguruma/src/config.h
+++ b/scintilla/oniguruma/src/config.h
@@ -96,4 +96,8 @@
 #define DLEXT ".so"
 #define DLEXT2 ".dll"
 
+#ifdef _WIN32_WINNT
+#pragma warning(disable: 4057 4100 4131 4201 4244 4245 4389 4456 4701 4703)
+#endif
+
 #endif //_ONIGURUMA_CONFIG_H_


### PR DESCRIPTION
+ chg: enable compiler warnings level 4 and issue "Warnings as Errors" (for Lexilla, Scintilla, grepWinNP3)