### PR TITLE
TinyExpr: UTF-8 to ANSI-CP-1252 conversion should yield invalid character

### DIFF
--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -209,7 +209,7 @@ static const int NUMTOOLBITMAPS = 30;
 
 // ----------------------------------------------------------------------------
 
-const char chr_currency[6] = { '$', 0x80, 0xA2, 0xA3, 0xA5, '\0' }; // "$€¢£¥"
+const char chr_currency[6] = { '$', 0x80, 0xA2, 0xA3, 0xA5, '\0' }; // "$€¢£¥" CP-1252
 
 // ----------------------------------------------------------------------------
 
@@ -2086,10 +2086,13 @@ static bool _EvalTinyExpr(bool qmark)
             DocPos const iLnCaretPos = SciCall_GetCurLine((lineLen - 1), lineBuf);
             lineBuf[iLnCaretPos - (posSelStart - posBefore)] = '\0'; // exclude "=?"
 
-            char const defchar = (char)0x24;
+            char const defchar = (char)te_invalid_chr();
             MultiByteToWideChar(Encoding_SciCP, 0, lineBuf, -1, lineBufW, lineLen);
-            WideCharToMultiByte(te_cp(), (WC_COMPOSITECHECK | WC_DISCARDNS), lineBufW, -1, lineBuf, lineLen, &defchar, NULL);
+            int const len = WideCharToMultiByte(te_cp(), (WC_COMPOSITECHECK | WC_DISCARDNS), lineBufW, -1, lineBuf, lineLen, &defchar, NULL);
             FreeMem(lineBufW);
+            if (!len) {
+                return false;
+            }
 
             // canonicalize fetched line
             StrDelChrA(lineBuf, chr_currency);

--- a/src/tinyexpr/tinyexpr.h
+++ b/src/tinyexpr/tinyexpr.h
@@ -108,6 +108,9 @@ void te_free(te_expr *n);
 /* ANSI codepage of te operators */
 inline unsigned te_cp() { return 1252U; }
 
+/* invalid default char for conversion */
+inline unsigned te_invalid_chr() { return '#'; }
+
 /* check for operator or special character. */
 inline int te_is_op(const char* const expr) {
     if (!expr)


### PR DESCRIPTION
… instead of blank or currency

ref. issue #3417