### PR TITLE
Fixing "infinite" loop in Markdown Lexer

### DIFF
--- a/lexilla/lexers_x/LexMarkdown.cxx
+++ b/lexilla/lexers_x/LexMarkdown.cxx
@@ -57,7 +57,7 @@
 using namespace Lexilla;
 
 constexpr bool IsNewline(const int ch) {
-    return (ch == '\n' || ch == '\r');
+    return (ch == '\n' || ch == '\r' || ch == '\0');
 }
 
 // True if can follow ch down to the end with possibly trailing whitespace


### PR DESCRIPTION
ref. issue #3514