### PR TITLE
 Goto-Dialog: digit grouping of line/column numbers

### DIFF
--- a/language/np3_af_za/strings_af_za.rc
+++ b/language/np3_af_za/strings_af_za.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Styl '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Geassosieerde lêernaam uitbreidings:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Zero-Lengte Pas"
-    IDS_MUI_GOTO_LINE       "Lyn (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Kolom (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Lyn (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Kolom (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_be_by/strings_be_by.rc
+++ b/language/np3_be_by/strings_be_by.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Стыль '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Звязаныя пашырэнні файлаў:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Супадзенне нулявой даўжыні"
-    IDS_MUI_GOTO_LINE       "Радок (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Слупок (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Радок (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Слупок (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_de_de/strings_de_de.rc
+++ b/language/np3_de_de/strings_de_de.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Stil '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Zugeordnete Dateitypen:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Null-Längen-Fund"
-    IDS_MUI_GOTO_LINE       "Zeile (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Spalte (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Zeile (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Spalte (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_el_gr/strings_el_gr.rc
+++ b/language/np3_el_gr/strings_el_gr.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Στυλ '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Συσχετισμένες επεκτάσεις ονομάτων αρχείων:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Συμφωνία μηδενικού μήκους"
-    IDS_MUI_GOTO_LINE       "Γραμμή (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Στήλη (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Γραμμή (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Στήλη (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_en_gb/strings_en_gb.rc
+++ b/language/np3_en_gb/strings_en_gb.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Style '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Associated filename extensions:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Zero-Length Match"
-    IDS_MUI_GOTO_LINE       "Line (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Column (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Line (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Column (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_en_us/strings_en_us.rc
+++ b/language/np3_en_us/strings_en_us.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Style '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Associated filename extensions:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Zero-Length Match"
-    IDS_MUI_GOTO_LINE       "Line (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Column (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Line (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Column (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_es_419/strings_es_419.rc
+++ b/language/np3_es_419/strings_es_419.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Estilo '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Extensiones de nombre de archivo asociadas:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Corresponde a longitud cero"
-    IDS_MUI_GOTO_LINE       "Línea (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Columna (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Línea (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Columna (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_es_es/strings_es_es.rc
+++ b/language/np3_es_es/strings_es_es.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Estilo '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Extensiones de nombre de archivo asociadas:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Corresponde a longitud cero"
-    IDS_MUI_GOTO_LINE       "Línea (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Columna (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Línea (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Columna (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_fr_fr/strings_fr_fr.rc
+++ b/language/np3_fr_fr/strings_fr_fr.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Style '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Extensions de fichiers associées :"
     IDS_MUI_ZERO_LEN_MATCH  "^ Correspondance de longueur zéro"
-    IDS_MUI_GOTO_LINE       "Ligne (1 - %ti) :"
-    IDS_MUI_GOTO_COLUMN     "Colonne (1 - %ti) :"
+    IDS_MUI_GOTO_LINE       "Ligne (1 - %s) :"
+    IDS_MUI_GOTO_COLUMN     "Colonne (1 - %s) :"
 END
 
 STRINGTABLE

--- a/language/np3_hi_in/strings_hi_in.rc
+++ b/language/np3_hi_in/strings_hi_in.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "शैली '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "संबंधित फ़ाईलनाम के प्रकार:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Zero-Length मिलान"
-    IDS_MUI_GOTO_LINE       "रेखा (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "खंड (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "रेखा (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "खंड (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_hu_hu/strings_hu_hu.rc
+++ b/language/np3_hu_hu/strings_hu_hu.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Stílus '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Hozzárendelt kiterjesztések:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Nulla hosszú egyezés"
-    IDS_MUI_GOTO_LINE       "Sor (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Oszlop (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Sor (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Oszlop (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_id_id/strings_id_id.rc
+++ b/language/np3_id_id/strings_id_id.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Style '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Associated filename extensions:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Zero-Length Match"
-    IDS_MUI_GOTO_LINE       "Line (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Column (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Line (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Column (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_it_it/strings_it_it.rc
+++ b/language/np3_it_it/strings_it_it.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Stile '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Estensioni associate:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Zero-Length Match"
-    IDS_MUI_GOTO_LINE       "Riga (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Colonna (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Riga (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Colonna (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_ja_jp/strings_ja_jp.rc
+++ b/language/np3_ja_jp/strings_ja_jp.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "%s のスタイル (%s)"
     IDS_MUI_ASSOCIATED_EXT  "関連付けるファイル拡張子:"
     IDS_MUI_ZERO_LEN_MATCH  "^ 空文字列に一致"
-    IDS_MUI_GOTO_LINE       "行 (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "列 (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "行 (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "列 (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_ko_kr/strings_ko_kr.rc
+++ b/language/np3_ko_kr/strings_ko_kr.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "스타일 '%s' - (%s)"
     IDS_MUI_ASSOCIATED_EXT  "연결된 파일 이름 확장자:"
     IDS_MUI_ZERO_LEN_MATCH  "^ 제로 길이 일치"
-    IDS_MUI_GOTO_LINE       "행 (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "열 (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "행 (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "열 (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_nl_nl/strings_nl_nl.rc
+++ b/language/np3_nl_nl/strings_nl_nl.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Stijl '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Bijbehorende bestandsextensies:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Nul-lengte Match"
-    IDS_MUI_GOTO_LINE       "Lijn (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Kolom (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Lijn (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Kolom (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_pt_br/strings_pt_br.rc
+++ b/language/np3_pt_br/strings_pt_br.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Estilo '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Extensão de nome de arquivo associada:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Pareamento de Tamanho Zero"
-    IDS_MUI_GOTO_LINE       "Linha (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Coluna (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Linha (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Coluna (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_pt_pt/strings_pt_pt.rc
+++ b/language/np3_pt_pt/strings_pt_pt.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Estilo '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Extensões de ficheiro associadas:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Corresponde ao comprimento zero"
-    IDS_MUI_GOTO_LINE       "Linha (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Coluna (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Linha (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Coluna (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_ru_ru/strings_ru_ru.rc
+++ b/language/np3_ru_ru/strings_ru_ru.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Стиль '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Связанные расширения файлов:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Совпадение нулевой длины"
-    IDS_MUI_GOTO_LINE       "Строка (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Колонка (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Строка (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Колонка (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_sk_sk/strings_sk_sk.rc
+++ b/language/np3_sk_sk/strings_sk_sk.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Štýl '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Priradené prípony súborov:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Zhoda s nulovou dĺžkou"
-    IDS_MUI_GOTO_LINE       "Riadok (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Stĺpec (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Riadok (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Stĺpec (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_sv_se/strings_sv_se.rc
+++ b/language/np3_sv_se/strings_sv_se.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "stil '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Associerade filnamnstillägg:"
     IDS_MUI_ZERO_LEN_MATCH  "^ nolllängdsträff"
-    IDS_MUI_GOTO_LINE       "Rad (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Kolumn (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Rad (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Kolumn (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_tr_tr/strings_tr_tr.rc
+++ b/language/np3_tr_tr/strings_tr_tr.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Stil '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Associated filename extensions:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Zero-Length Match"
-    IDS_MUI_GOTO_LINE       "Line (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Column (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Line (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Column (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_vi_vn/strings_vi_vn.rc
+++ b/language/np3_vi_vn/strings_vi_vn.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Style '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Associated filename extensions:"
     IDS_MUI_ZERO_LEN_MATCH  "^ Zero-Length Match"
-    IDS_MUI_GOTO_LINE       "Line (1 - %ti):"
-    IDS_MUI_GOTO_COLUMN     "Column (1 - %ti):"
+    IDS_MUI_GOTO_LINE       "Line (1 - %s):"
+    IDS_MUI_GOTO_COLUMN     "Column (1 - %s):"
 END
 
 STRINGTABLE

--- a/language/np3_zh_cn/strings_zh_cn.rc
+++ b/language/np3_zh_cn/strings_zh_cn.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Style '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "关联的文件扩展名："
     IDS_MUI_ZERO_LEN_MATCH  "^ 零宽度匹配"
-    IDS_MUI_GOTO_LINE       "行（1 - %ti）："
-    IDS_MUI_GOTO_COLUMN     "列（1 - %ti）："
+    IDS_MUI_GOTO_LINE       "行（1 - %s）："
+    IDS_MUI_GOTO_COLUMN     "列（1 - %s）："
 END
 
 STRINGTABLE

--- a/language/np3_zh_tw/strings_zh_tw.rc
+++ b/language/np3_zh_tw/strings_zh_tw.rc
@@ -250,8 +250,8 @@ BEGIN
     IDS_MUI_TITLE_FIXARB    "Style '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "關聯的副檔名："
     IDS_MUI_ZERO_LEN_MATCH  "^ 零寬度符合"
-    IDS_MUI_GOTO_LINE       "行（1 - %ti）："
-    IDS_MUI_GOTO_COLUMN     "列（1 - %ti）："
+    IDS_MUI_GOTO_LINE       "行（1 - %s）："
+    IDS_MUI_GOTO_COLUMN     "列（1 - %s）："
 END
 
 STRINGTABLE

--- a/src/Config/Config.cpp
+++ b/src/Config/Config.cpp
@@ -2594,29 +2594,16 @@ static bool CreateNewDocument(const char* lpstrText, DocPosU lenText, int docOpt
     if (!lpstrText || (lenText == 0)) {
         SciCall_SetDocPointer(0);
     } else {
-#if FALSE
-        ILoader* const pDocLoad = reinterpret_cast<ILoader*>(SciCall_CreateLoader(static_cast<Sci_Position>(lenText) + 1, docOptions));
-
-        if (SC_STATUS_OK != pDocLoad->AddData(lpstrText, lenText)) {
-            RELEASE_RETURN(false);
-        }
-        sptr_t const pNewDocumentPtr = (sptr_t)pDocLoad->ConvertToDocument(); // == SciCall_CreateDocument(lenText, docOptions);
-        if (!pNewDocumentPtr) {
-            RELEASE_RETURN(false);
-        }
-        SciCall_SetDocPointer(pNewDocumentPtr);
-        SciCall_ReleaseDocument(pNewDocumentPtr);
-#else
         sptr_t const pNewDocumentPtr = SciCall_CreateDocument(lenText, docOptions);
         if (pNewDocumentPtr) {
             SciCall_SetDocPointer(pNewDocumentPtr);
             SciCall_ReleaseDocument(pNewDocumentPtr);
-        } else {
+        }
+        else {
             SciCall_SetDocPointer(0);
         }
         SciCall_TargetWholeDocument();
         SciCall_ReplaceTarget(lenText, lpstrText);
-#endif
     }
     return true;
 }
@@ -2640,7 +2627,7 @@ extern "C" bool EditSetDocumentBuffer(const char* lpstrText, DocPosU lenText)
     bool const bLargerThan2GB = (lenText >= ((DocPosU)INT32_MAX));
     bool const bLargeFileLoaded = (lenText >= ((DocPosU)Settings2.FileLoadWarningMB << 20));
     int const docOptions = bLargeFileLoaded ? (bLargerThan2GB ? SC_DOCUMENTOPTION_TEXT_LARGE : SC_DOCUMENTOPTION_STYLES_NONE)
-                           : SC_DOCUMENTOPTION_DEFAULT;
+                                                              : SC_DOCUMENTOPTION_DEFAULT;
 
     if (SciCall_GetDocumentOptions() != docOptions) {
         // we have to create a new document with changed options

--- a/src/Helpers.c
+++ b/src/Helpers.c
@@ -2170,8 +2170,10 @@ int Hex2Char(char* ch, int cnt)
 }
 
 
-
 #ifdef WC2MB_EX
+
+TODO:  how to avoid Code-Point truncation/splitting
+
 //=============================================================================
 //
 //  WideCharToMultiByteEx()
@@ -2224,6 +2226,9 @@ ptrdiff_t WideCharToMultiByteEx(
 #endif
 
 #ifdef MB2WC_EX
+
+TODO:  how to avoid Code-Point truncation/splitting
+
 //=============================================================================
 //
 //  MultiByteToWideCharEx()


### PR DESCRIPTION
 +chg: limit file size: 2GB (Until WideCharToMultiByte() / MultiByteToWideChar() INT32_MAX issues are clarified)


ref. issue #3656.