### PR TITLE
Disable actively file change polling - rely on directory change notification by default

### DIFF
--- a/Build/Notepad3.ini
+++ b/Build/Notepad3.ini
@@ -5,7 +5,6 @@
 SettingsVersion=5
 [Settings2]
 ;IMEInteraction=0
-;AutoReloadTimeout=2000
 ;DateTimeFormat=          (-> <Locale dependent short format>)
 ;DateTimeLongFormat=      (-> <Locale dependent long format>)
 ;TimeStampRegEx=          (-> \$Date:[^\$]+\$ ) (Find-Pattern to Update Stamps)
@@ -16,7 +15,7 @@ SettingsVersion=5
 ;DenyVirtualSpaceAccess=0
 ;filebrowser.exe=minipath.exe
 ;grepWin.exe=grepWinNP3.exe
-;FileCheckInverval=2000
+;FileCheckInverval=0
 ;FileChangedIndicator=[@]
 ;FileDeletedIndicator=[X]
 ;FileDlgFilters=

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -5699,12 +5699,12 @@ LRESULT MsgCommand(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
             SendWMCommand(hwnd, IDM_FILE_REVERT);
             _saveChgNotify = FileWatching.FileWatchingMode;
             FileWatching.FileWatchingMode = FWM_AUTORELOAD;
-            FileWatching.AutoReloadTimeout = 250UL;
+            FileWatching.FileCheckInverval = 250UL;
             UndoRedoRecordingStop();
             SciCall_SetEndAtLastLine(false);
         } else {
             FileWatching.FileWatchingMode = _saveChgNotify;
-            FileWatching.AutoReloadTimeout = Settings2.AutoReloadTimeout;
+            FileWatching.FileCheckInverval = Settings2.FileCheckInverval;
             UndoRedoRecordingStart();
             SciCall_SetEndAtLastLine(!Settings.ScrollPastEOF);
         }
@@ -11452,7 +11452,8 @@ static inline void NotifyIfFileHasChanged(const bool forcedNotify) {
 }
 // ----------------------------------------------------------------------------
 
-
+// FWM_MSGBOX (polling: FileWatching.FileCheckInverval)
+// FWM_AUTORELOAD (also FileWatching.MonitoringLog)
 static void CALLBACK WatchTimerProc(HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime) {
 
     UNREFERENCED_PARAMETER(dwTime);
@@ -11462,23 +11463,9 @@ static void CALLBACK WatchTimerProc(HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWOR
 
     DWORD const diff = GetTickCount() - s_dwFileChangeNotifyTime;
 
-    //if (HasDirChanged()) {
-    //    ResetEventDirChanged();
-    //    NotifyIfFileHasChanged(false);
-    //} else 
+    // Directory-Observer is not notified for continously updated (log-)files
     if (diff > Settings2.FileCheckInverval) {
-        // FWM_MSGBOX (polling: FileWatching.FileCheckInverval)
-        // Directory-Observer is not notified for continously updated (log-)files
-        NotifyIfFileHasChanged(false);
-    } else if (diff > FileWatching.AutoReloadTimeout) {
-        // FWM_AUTORELOAD (also FileWatching.MonitoringLog)
-        if (FileWatching.MonitoringLog) {
-            // monitoring: reload only on change
-            NotifyIfFileHasChanged(false);
-        } else {
-            // unconditional reload
-            NotifyIfFileHasChanged(false);
-        }
+        NotifyIfFileHasChanged(/*FileWatching.MonitoringLog*/ false);
     }
 }
 // ----------------------------------------------------------------------------
@@ -11616,7 +11603,12 @@ void InstallFileWatching(const bool bInstall) {
             }
 
             s_dwFileChangeNotifyTime = (FileWatching.FileWatchingMode == FWM_AUTORELOAD) ? GetTickCount() : 0UL;
-            SetTimer(Globals.hwndMain, ID_WATCHTIMER, min_dw(Settings2.FileCheckInverval, FileWatching.AutoReloadTimeout), WatchTimerProc);
+            if (FileWatching.FileCheckInverval > 0) {
+                SetTimer(Globals.hwndMain, ID_WATCHTIMER, FileWatching.FileCheckInverval, WatchTimerProc);
+            }
+            else {
+                KillTimer(Globals.hwndMain, ID_WATCHTIMER);
+            }
 
         } else if (bExclusiveLock) {
 

--- a/src/TypeDefs.h
+++ b/src/TypeDefs.h
@@ -612,7 +612,6 @@ typedef struct _settings2_t
     int    OpacityLevel;
     int    FindReplaceOpacityLevel;
     DWORD  FileCheckInverval;
-    DWORD  AutoReloadTimeout;
     DWORD  UndoTransactionTimeout;
     int    IMEInteraction;
     int    SciFontQuality;
@@ -699,8 +698,8 @@ typedef struct _filewatching_t
 {
     FILE_WATCHING_MODE flagChangeNotify;  // <-> s_flagChangeNotify;
     FILE_WATCHING_MODE FileWatchingMode;  // <-> Settings.FileWatchingMode;
-    DWORD AutoReloadTimeout;              // <-> Settings2.AutoReloadTimeout;
-    bool MonitoringLog;
+    DWORD              FileCheckInverval; // <-> Settings2.FileCheckInverval;
+    bool               MonitoringLog;
 
 } FILEWATCHING_T, *PFILEWATCHING_T;
 


### PR DESCRIPTION
+chg: allow [Settings2] "FileCheckInverval" to be zero(0), means no active file change polling
+chg: remove deprecated "AutoReloadTimeout"

ref. issue #3516