### PR TITLE
Update dialogs_nl_nl.rc

### DIFF
--- a/language/np3_nl_nl/dialogs_nl_nl.rc
+++ b/language/np3_nl_nl/dialogs_nl_nl.rc
@@ -98,11 +98,11 @@ BEGIN
     CONTROL         "Reguliere &expressie",IDC_FINDREGEXP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,85,96,10
     CONTROL         "Punt &matches alles",IDC_DOT_MATCH_ALL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,18,96,65,10
     CONTROL         "Niet opnieuw zoeken",IDC_NOWRAP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,37,75,10
-    CONTROL         "S&toppen bij overeenkomst",IDC_FINDCLOSE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,49,65,10
-    CONTROL         "Overeenkomsten mar&keren",IDC_ALL_OCCURRENCES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,61,73,10
+    CONTROL         "S&luiten na vinden",IDC_FINDCLOSE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,49,65,10
+    CONTROL         "Mar&keren",IDC_ALL_OCCURRENCES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,61,73,10
     CONTROL         "&Met jokertekens",IDC_WILDCARDSEARCH,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,85,63,10
     CONTROL         "Venster transparant maken bij verlies van focus",IDC_TRANSPARENT,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,118,134,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,118,154,10
     DEFPUSHBUTTON   "Vo&lgende",IDOK,211,7,55,14
     PUSHBUTTON      "Vo&rige",IDC_FINDPREV,211,24,55,14
     PUSHBUTTON      "Sluiten",IDCANCEL,211,99,55,14
@@ -122,7 +122,7 @@ BEGIN
     LTEXT           "Zoeken naar:",IDC_STATIC,7,7,46,8
     CONTROL         "<a>Esc Ctrl-teken.</a>", IDC_FINDESCCTRLCHR, "SysLink", 0x0, 70, 7, 60, 10
     COMBOBOX        IDC_FINDTEXT,7,17,192,116,CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Vervangen door:",IDC_STATIC2,7,36,48,8
+    LTEXT           "Vervangen door:",IDC_STATIC2,7,36,55,8
     CONTROL         "<a>Esc Ctrl-teken.</a>", IDC_REPLESCCTRLCHR, "SysLink", 0x0, 70, 36, 60, 10
     COMBOBOX        IDC_REPLACETEXT,7,47,192,116,CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
     CONTROL         "&Hoofdlettergevoelig",IDC_FINDCASE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,66,110,10
@@ -132,11 +132,11 @@ BEGIN
     CONTROL         "Reguliere &expressie",IDC_FINDREGEXP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,114,97,10
     CONTROL         "Punt &matches alles",IDC_DOT_MATCH_ALL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,18,125,65,10
     CONTROL         "Niet opnieuw zoeken",IDC_NOWRAP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,66,75,10
-    CONTROL         "S&toppen bij overeenkomst",IDC_FINDCLOSE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,78,85,10
-    CONTROL         "Overeenkomsten mar&keren",IDC_ALL_OCCURRENCES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,90,73,10
+    CONTROL         "S&luiten na vervangen",IDC_FINDCLOSE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,78,85,10
+    CONTROL         "Mar&keren",IDC_ALL_OCCURRENCES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,90,73,10
     CONTROL         "&Met jokertekens",IDC_WILDCARDSEARCH,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,114,63,10
     CONTROL         "Venster transparant maken bij verlies van focus",IDC_TRANSPARENT,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,144,134,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,144,154,10
     DEFPUSHBUTTON   "Vo&lgende",IDOK,211,7,55,14
     PUSHBUTTON      "Vo&rige",IDC_FINDPREV,211,23,55,14
     PUSHBUTTON      "&Vervangen",IDC_REPLACE,211,43,55,14
@@ -1095,4 +1095,5 @@ END
 
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
+
 


### PR DESCRIPTION
4 small changes as per request.
Please understand that English is one of the most compact languages in the world and therefore not the best reference for GUI dimensions. Germanic languages like Dutch, German and, I suppose, the Nordic languages do require more character space.
Close after find := Sluiten na vinden = Schließen nach finden
Close after replace := Sluiten na vervangen = Schließen nach ersetzen
Just "Close"/"Sluiten" seems to me not enough, it just wouldn't be clear what is meant here.

Aha! 
Upon checking the diff shown at the commit, it'd appear to me that you've already widened the string space somewhat. Possibly this can be reduced a bit again.