### PR TITLE
Changed IDM_VIEW_TOGGLE_VIEW translation

### DIFF
--- a/language/np3_zh_cn/menu_zh_cn.rc
+++ b/language/np3_zh_cn/menu_zh_cn.rc
@@ -396,7 +396,7 @@ BEGIN
         END
         POPUP "显示(&D)"
         BEGIN
-            MENUITEM "切换聚焦(&F)\tCtrl+Alt+V",             IDM_VIEW_TOGGLE_VIEW
+            MENUITEM "专注模式(&F)\tCtrl+Alt+V",             IDM_VIEW_TOGGLE_VIEW
             POPUP "查看模式"
             BEGIN
                 MENUITEM "折叠",                            IDM_VIEW_FV_FOLD

--- a/language/np3_zh_tw/menu_zh_tw.rc
+++ b/language/np3_zh_tw/menu_zh_tw.rc
@@ -396,7 +396,7 @@ BEGIN
         END
         POPUP "顯示(&D)"
         BEGIN
-            MENUITEM "切換聚焦(&F)\tCtrl+Alt+V",             IDM_VIEW_TOGGLE_VIEW
+            MENUITEM "專注模式(&F)\tCtrl+Alt+V",             IDM_VIEW_TOGGLE_VIEW
             POPUP "檢視模式"
             BEGIN
                 MENUITEM "摺疊",                            IDM_VIEW_FV_FOLD


### PR DESCRIPTION
The original translation "切换聚焦" is confusing, similar to "Switch focus" or "Toggle focused".
The new translation means Focus mode (engrossing mode), it is used by iOS and more.

Ref: https://support.apple.com/en-us/HT212608, https://support.apple.com/zh-cn/HT212608, https://support.apple.com/zh-tw/HT212608.