### PR TITLE
Update Fortran keywords

### DIFF
--- a/src/StyleLexers/styleLexFortran.c
+++ b/src/StyleLexers/styleLexFortran.c
@@ -4,39 +4,69 @@
 
 // https://en.wikibooks.org/wiki/Fortran
 // https://releases.llvm.org/11.0.0/tools/flang/docs/Intrinsics.html
+// https://fortranwiki.org/fortran/show/Keywords
+// Fortran Standard 2018
 
 // ----------------------------------------------------------------------------
 
 KEYWORDLIST KeyWords_Fortran =
 {
     // Primary keywords and identifiers
-    "access action advance allocatable allocate apostrophe assign assignment associate asynchronous "
-    "backspace bind blank blockdata call case character class close common complex contains continue cycle "
-    "data deallocate decimal delim default dimension direct do dowhile double doubleprecision "
-    "else elseif elsewhere encoding end endassociate endblockdata enddo endfile endforall endfunction "
-    "endif endinterface endmodule endprogram endselect endsubroutine endtype endwhere entry eor "
-    "equivalence err errmsg exist exit external file flush fmt forall form format formatted function "
-    "go goto id if implicit in include inout integer inquire intent interface intrinsic iomsg iolength iostat "
-    "kind len logical module name named namelist nextrec nml none nullify number only open opened operator optional out "
-    "pad parameter pass pause pending pointer pos position precision print private program protected public "
-    "quote readwrite read real rec recl recursive result return rewind save select selectcase selecttype sequential "
-    "sign size stat status stop stream subroutine target then to type unformatted unit use value volatile wait where while write",
+    "abstract access action advance all allocatable allocate apostrophe assign assignment associate asynchronous "
+    "backspace bind blank block blockdata call case change character class close codimension common complex concurrent "
+    "contains contiguous continue critical cycle "
+    "data deallocate decimal delim default deferred dimension direct do dowhile double doubleprecision "
+    "elemental else elseif elsewhere encoding end endassociate endblock endblockdata endcritical enddo endenum endfile "
+    "endforall endfunction endif endinterface endmodule endprogram endprocedure endselect endsubroutine endsubmodule "
+    "endteam endtype endwhere entry enum enumerator eor equivalence err error errmsg event exist exit extends external "
+    "fail file final flush fmt forall form format formatted function generic go goto "
+    "id if im image images implicit import impure in include inout integer inquire intent interface intrinsic iomsg "
+    "iolength iostat kind len lock logical memory module name named namelist nextrec newunit nml none "
+    "non_intrinsic non_overridable nopass nullify number only open opened operator optional out "
+    "pad parameter pass pause pending pointer pos post position precision print private procedure program protected public pure "
+    "quote rank re readwrite read real rec recl recursive result return rewind round "
+    "save select selectcase selecttype selectrank sequence sequential sign size stat status stop stream subroutine submodule "
+    "sync target team then to type unformatted unit unlock use "
+    "value volatile wait where while write ",
 
-    // Intrinsic functions
-    "achar adjustl adjustr aimag aint alog alog10 amax0 amax1 amin0 amin1 amod anint associated atan2 baddress "
-    "bessel_j0 bessel_j1 bessel_y0 bessel_y1 bge bgt bit_size ble blt btest cabs cachesize ccos ceiling cexp char "
-    "clog command_argument_count compl conjg coshape cotan cotand cshift csin csqrt ctan dabs dacos dasin datan "
-    "datan2 dble dcos dcosh ddim dexp dfloat digits dint dlog dlog10 dmax1 dmin1 dmod dnint dnum dprod dsign dsin "
-    "dsinh dsqrt dtan dtanh eof eoshift epsilon eqv erf erfc erfc_scaled exponent extends_type_of failed_images "
-    "float floor fp_class fraction gamma get_team hypot iabs iachar iaddr iarg iargc ibchng ibclr ibits ibset ichar "
-    "idim idint idnint ifix ilen image_status index int int_ptr_kind int8 inum is_contiguous is_iostat_end "
-    "is_iostat_eor isha ishc ishft ishftc ishl isign isnan ixor izext jint jnint jnum kind knint knum lbound "
-    "lcobound leadz len len_trim lge lgt lle llt log_gamma log10 logical malloc maskl maskr max0 max1 maxexponent "
-    "mclock merge min0 min1 minexponent nargs nearest neqv new_line nint not null numarg pack popcnt poppar "
-    "precision present qcmplx qext qfloat qnum qreal radix ran ranf range rank real reduce repeat reshape rnum "
-    "rrspacing same_type_as scale scan secnds selected_char_kind selected_int_kind selected_real_kind set_exponent "
-    "shape shift shifta shiftl shiftr size sizeof sngl spacing spread stopped_images storage_size team_number "
-    "this_image tiny trailz transpose trim ubound ucobound unpack verify",
+    // Intrinsic functions (Fortran Standard 2018)
+    // Standard generic intrinsic procedures
+    "abs achar acos acosh adjustl adjustr aimag aint all allocated anint any asin asinh associated atan atan2 atanh "
+    "atomic_add atomic_and atomic_cas atomic_define atomic_fetch_add atomic_fetch_and atomic_fetch_or atomic_fetch_xor atomic_or "
+    "atomic_ref atomic_xor bessel_j0 bessel_j1 bessel_jn bessel_y0 bessel_y1 bessel_yn bge bgt bit_size ble blt btest "
+    "ceiling char cmplx co_broadcast co_max co_min co_reduce co_sum command_argument_count conjg cos cosh coshape count cpu_time "
+    "cshift date_and_time dble digits dim dot_product dprod dshiftl dshiftr eoshift epsilon erf erfc erfc_scaled event_query "
+    "execute_command_line exp exponent extends_type_of failed_images findloc floor fraction gamma "
+    "get_command get_command_argument get_environment_variable get_team "
+    "huge hypot iachar iall iand iany ibclr ibits ibset ichar ieor image_index image_status index int ior iparity ishft ishftc "
+    "is_contiguous is_iostat_end is_iostat_eor kind lbound lcobound leadz len len_trim lge lgt lle llt log log_gamma log10 "
+    "logical maskl maskr matmul max maxexponent maxloc maxval merge merge_bits min minexponent minloc minval mod modulo "
+    "move_alloc mvbits nearest new_line nint norm2 not null num_images out_of_range pack parity popcnt poppar precision "
+    "present product radix random_init random_number random_seed range rank real reduce repeat reshape rrspacing "
+    "same_type_as scale scan selected_char_kind selected_int_kind selected_real_kind set_exponent "
+    "shape shift shifta shiftl shiftr sign sin sinh size spacing spread sqrt stopped_images storage_size sum "
+    "system_clock tan tanh team_number this_image tiny trailz transfer transpose trim ubound ucobound unpack verify "
+    // Unrestricted specific names for standard intrinsic procedures
+    "alog alog10 amod anint asin cabs ccos cexp clog csin csqrt dabs dacos dasin datan datan2 dcos dcosh ddim dexp "
+    "dint dlog dlog10 dmod dnint dsign dsin dsinh dsqrt dtan dtanh iabs idim idnint isign "
+    // Restricted specific names for standard intrinsic procedures
+    "amax0 amax1 amin0 amin1 dmax1 dmin1 float idint ifix max0 max1 min0 min1 sngl "
+    // Intrinsic procedures for the IEEE_ARITHMETIC module
+    "ieee_class ieee_copy_sign ieee_fma ieee_get_rounding_mode ieee_get_underflow_mode ieee_int ieee_is_finite "
+    "ieee_nan ieee_is_negative ieee_is_normal ieee_logb ieee_max_num ieee_max_num_mag ieee_min_num ieee_min_num_mag "
+    "ieee_next_after ieee_next_down ieee_next_up ieee_quiet_eq ieee_quiet_ge ieee_quiet_gt ieee_quiet_le ieee_quiet_lt "
+    "ieee_quiet_ne ieee_real ieee_rem ieee_rint ieee_scalb ieee_selected_real_kind ieee_set_rounding_mode "
+    "ieee_set_underflow_mode ieee_signaling_eq ieee_signaling_ge ieee_singaling_gt ieee_singaling_le ieee_singaling_lt "
+    "ieee_singaling_ne ieee_signbit ieee_support_datatype ieee_support_denormal ieee_support_divide ieee_support_inf "
+    "ieee_support_io ieee_support_rounding ieee_support_sqrt ieee_support_subnormal ieee_support_standard "
+    "ieee_support_underflow_control ieee_unordered ieee_value "
+    // Intrinsic procedures for the IEEE_EXCEPTIONS module
+    "ieee_get_flag ieee_get_halting_mode ieee_get_modes ieee_get_status ieee_set_halting_mode ieee_set_modes ieee_set_status "
+    "ieee_support_flag ieee_support_halting_mode "
+    // Intrinsic procedures for the ISO_FORTRAN_ENV module
+    "compiler_options compiler_version "
+    // Intrinsic procedures for the ISO_C_BINDING module
+    "c_associated c_f_pointer c_f_procpointer c_funloc c_loc c_sizeof",
 
     // Extended and user defined functions
     "",


### PR DESCRIPTION
- [x] Update Fortran syntax highlight keywords according to Fortran 2018 (_latest_) standard.

Note: Extension syntaxes of `GFortran` and `IFort` compilers are not added.

**Effects**
![image](https://user-images.githubusercontent.com/32035096/144392202-8683195e-eab2-43fd-8c08-5d2ae335f75b.png)

cc @RaiKoHoff , @GJYAQXT