### PR TITLE
Fix horizontal mouse wheel with Logitech Options utility

### DIFF
--- a/scintilla/win32/ScintillaWin.cxx
+++ b/scintilla/win32/ScintillaWin.cxx
@@ -1665,7 +1665,7 @@ sptr_t ScintillaWin::MouseMessage(unsigned int iMessage, uptr_t wParam, sptr_t l
 			int const xPos = std::min(xOffset + charsToScroll, scrollWidth - static_cast<int>(rcText.Width()) + 1);
 			HorizontalScrollTo(xPos);
 		}
-		return 0;
+		return 1;
 	// <<<<<<<<<<<<<<<   END NON STD SCI PATCH   <<<<<<<<<<<<<<<
 
 	}


### PR DESCRIPTION
Logitech horizontal mouse wheel not working in Notepad3 with Logitech Options installed.
This is a common problem caused by crooked Logitech software.
![hwheel](https://user-images.githubusercontent.com/5181651/154522344-7cc053ab-d34f-4caf-897c-73b20837255e.gif)
This problem is consistently repeated in other text editors based on Scintilla, and also in standard Delphi VCL components.
If you follow the documentation and return in response to `WM_MOUSEHWHEEL` `0`, then Logitech Options (or Windows) stops sending `WM_MOUSEHWHEEL` altogether, the scrollbar loses its style and moves without any messages (which can be processed in WndProc). If you return `1`, then magically everything starts working correctly. There is another `return 0` above in the code, but according to my tests, it does not lead to this problem.

Closes #3976.