### PR TITLE
+fix: using by error 'Segoe UI'' as default for pure 'Text File' scheme

### DIFF
--- a/src/Styles.c
+++ b/src/Styles.c
@@ -2852,6 +2852,8 @@ static inline unsigned GetDefaultTextFont(LPWSTR pwchFontName, int cchFont)
         L"Cascadia Mono",
         L"Roboto Mono",
         L"DejaVu Sans Mono",
+        L"Consolas",
+        L"Lucida Console"
     };
     unsigned const countof = COUNTOF(FontNamePrioList);
 


### PR DESCRIPTION
ref. issue https://github.com/rizonesoft/Notepad3/issues/4020