### PR TITLE
Hotfix for crash in SCI_FINDTEXTFULL

### DIFF
--- a/language/common_res.h
+++ b/language/common_res.h
@@ -465,6 +465,15 @@
 #define IDC_CHECK_BOX_B                 18252
 #define IDC_CHECK_BOX_C                 18253
 
+#define IDC_MODLNS_ED_PREPEND           100
+#define IDC_MODLNS_ED_APPEND            101
+#define IDC_MODLNS_DOCLN_CANONIC        200
+#define IDC_MODLNS_DOCLN_ZEROFLD        201
+#define IDC_MODLNS_CNTLN1_CANONIC       202
+#define IDC_MODLNS_CNTLN1_ZEROFLD       203
+#define IDC_MODLNS_CNTLN0_CANONIC       204
+#define IDC_MODLNS_CNTLN0_ZEROFLD       205
+
 #define CMD_ESCAPE                      20000
 #define CMD_SHIFTESC                    20001
 #define CMD_SHIFTCTRLENTER              20002

--- a/language/np3_de_de/dialogs_de_de.rc
+++ b/language/np3_de_de/dialogs_de_de.rc
@@ -516,19 +516,19 @@ CAPTION "Zeilen Modifizieren"
 FONT 9, "Segoe UI", 0, 0, 0x0
 BEGIN
     LTEXT           "&Voranstellen:",IDC_STATIC,7,7,120,8
-    EDITTEXT        100,7,18,98,14,ES_AUTOHSCROLL
+    EDITTEXT        IDC_MODLNS_ED_PREPEND,7,18,98,14,ES_AUTOHSCROLL
     LTEXT           "&Anhängen:",IDC_STATIC2,7,37,120,8
-    EDITTEXT        101,7,48,98,14,ES_AUTOHSCROLL
+    EDITTEXT        IDC_MODLNS_ED_APPEND,7,48,98,14,ES_AUTOHSCROLL
     DEFPUSHBUTTON   "OK",IDOK,125,7,50,14
     PUSHBUTTON      "Abbrechen",IDCANCEL,125,24,50,14
-    LTEXT           "$(L)",200,7,72,14,8
-    LTEXT           "$(0L)",201,30,72,18,8
+    LTEXT           "$(L)",IDC_MODLNS_DOCLN_CANONIC,7,72,14,8
+    LTEXT           "$(0L)",IDC_MODLNS_DOCLN_ZEROFLD,30,72,18,8
     LTEXT           "Document Zeilen-Nummer.",IDC_STATIC3,57,72,120,8
-    LTEXT           "$(N)",202,7,82,15,8
-    LTEXT           "$(0N)",203,30,82,19,8
+    LTEXT           "$(N)",IDC_MODLNS_CNTLN1_CANONIC,7,82,15,8
+    LTEXT           "$(0N)",IDC_MODLNS_CNTLN1_ZEROFLD,30,82,19,8
     LTEXT           "Fortlaufend (mit 1 beginnend).",IDC_STATIC4,57,82,120,8
-    LTEXT           "$(I)",204,7,92,13,8
-    LTEXT           "$(0I)",205,30,92,17,8
+    LTEXT           "$(I)",IDC_MODLNS_CNTLN0_CANONIC,7,92,13,8
+    LTEXT           "$(0I)",IDC_MODLNS_CNTLN0_ZEROFLD,30,92,17,8
     LTEXT           "Fortlaufende (mit 0 beginnend).",IDC_STATIC5,57,92,120,8
 END
 

--- a/language/np3_en_us/dialogs_en_us.rc
+++ b/language/np3_en_us/dialogs_en_us.rc
@@ -516,19 +516,19 @@ CAPTION "Modify Lines"
 FONT 9, "Segoe UI", 0, 0, 0x0
 BEGIN
     LTEXT           "&Prefix text to lines:",IDC_STATIC,7,7,62,8
-    EDITTEXT        100,7,18,98,14,ES_AUTOHSCROLL
+    EDITTEXT        IDC_MODLNS_ED_PREPEND,7,18,98,14,ES_AUTOHSCROLL
     LTEXT           "&Append text to lines:",IDC_STATIC2,7,37,68,8
-    EDITTEXT        101,7,48,98,14,ES_AUTOHSCROLL
+    EDITTEXT        IDC_MODLNS_ED_APPEND,7,48,98,14,ES_AUTOHSCROLL
     DEFPUSHBUTTON   "OK",IDOK,125,7,50,14
     PUSHBUTTON      "Cancel",IDCANCEL,125,24,50,14
-    LTEXT           "$(L)",200,7,72,14,8
-    LTEXT           "$(0L)",201,30,72,18,8
+    LTEXT           "$(L)",IDC_MODLNS_DOCLN_CANONIC,7,72,14,8
+    LTEXT           "$(0L)",IDC_MODLNS_DOCLN_ZEROFLD,30,72,18,8
     LTEXT           "Document line number.",IDC_STATIC3,57,72,74,8
-    LTEXT           "$(N)",202,7,82,15,8
-    LTEXT           "$(0N)",203,30,82,19,8
+    LTEXT           "$(N)",IDC_MODLNS_CNTLN1_CANONIC,7,82,15,8
+    LTEXT           "$(0N)",IDC_MODLNS_CNTLN1_ZEROFLD,30,82,19,8
     LTEXT           "Continuous number.",IDC_STATIC4,57,82,66,8
-    LTEXT           "$(I)",204,7,92,13,8
-    LTEXT           "$(0I)",205,30,92,17,8
+    LTEXT           "$(I)",IDC_MODLNS_CNTLN0_CANONIC,7,92,13,8
+    LTEXT           "$(0I)",IDC_MODLNS_CNTLN0_ZEROFLD,30,92,17,8
     LTEXT           "Continuous number (zero-based).",IDC_STATIC5,57,92,109,8
 END
 

--- a/src/Config/Config.cpp
+++ b/src/Config/Config.cpp
@@ -2315,7 +2315,7 @@ void CmdSaveSettingsNow()
             return;
         }
         if (dwFileAttributes & FILE_ATTRIBUTE_READONLY) {
-            if (IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_INIFILE_READONLY))) {
+            if (IsYesOkay(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_INIFILE_READONLY))) {
                 Path_SetFileAttributes(Paths.IniFile, FILE_ATTRIBUTE_NORMAL); // override read-only attrib
                 Globals.bCanSaveIniFile = CanAccessPath(Paths.IniFile, GENERIC_WRITE);
             }

--- a/src/Dialogs.c
+++ b/src/Dialogs.c
@@ -2540,7 +2540,7 @@ CASE_WM_CTLCOLOR_SET:
                     LONG const answer = (LOWORD(wParam) == IDOK) ? InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_ERR_MRUDLG)
                                         : ((iCur == lvi.iItem) ? IDNO : IDYES);
 
-                    if (IsYesOkayRetryContinue(answer)) {
+                    if (IsYesOkay(answer)) {
                         MRU_Delete(Globals.pFileMRU, lvi.iItem);
                         //SendDlgItemMessage(hwnd,IDC_FILEMRU,LB_DELETESTRING,(WPARAM)iItem,0);
                         //ListView_DeleteItem(GetDlgItem(hwnd,IDC_FILEMRU),lvi.iItem);
@@ -5010,7 +5010,7 @@ void DialogAdminExe(HWND hwnd, bool bExecInstaller)
     sei.nShow = SW_SHOWNORMAL;
     if (bExecInstaller) {
         ShellExecuteExW(&sei);
-        if (IsYesOkayRetryContinue(InfoBoxLng(MB_OKCANCEL, L"NoAdminTool", IDS_MUI_ERR_ADMINEXE))) {
+        if (IsYesOkay(InfoBoxLng(MB_OKCANCEL, L"NoAdminTool", IDS_MUI_ERR_ADMINEXE))) {
             sei.lpFile = VERSION_UPDATE_CHECK;
             ShellExecuteExW(&sei);
         }

--- a/src/Dialogs.h
+++ b/src/Dialogs.h
@@ -81,8 +81,14 @@ DWORD MsgBoxLastError(LPCWSTR lpszMessage, DWORD dwErrID);
 LONG InfoBoxLng(UINT uType, LPCWSTR lpstrSetting, UINT uidMsg, ...);
 #define INFOBOX_ANSW(_R_) LOWORD(_R_)
 #define INFOBOX_MODE(_R_) HIWORD(_R_)
-inline bool IsYesOkayRetryContinue(LONG answ) {
-    return ((LOWORD(answ) == IDOK) || (LOWORD(answ) == IDYES) || (LOWORD(answ) == IDRETRY) || (LOWORD(answ) == IDCONTINUE));
+inline bool IsYesOkay(LONG answ) {
+    return ((LOWORD(answ) == IDOK) || (LOWORD(answ) == IDYES));
+}
+inline bool IsRetryContinue(LONG answ) {
+    return ((LOWORD(answ) == IDRETRY) || (LOWORD(answ) == IDCONTINUE));
+}
+inline bool IsNoCancel(LONG answ) {
+    return ((LOWORD(answ) == IDNO) || (LOWORD(answ) == IDCANCEL));
 }
 
 void SetWindowTitle(HWND hwnd, const HPATHL pthFilePath, int iFormat,

--- a/src/Edit.c
+++ b/src/Edit.c
@@ -559,7 +559,7 @@ bool EditSetNewEncoding(HWND hwnd, cpi_enc_t iNewEncoding, bool bSupressWarning)
 
         if (Sci_IsDocEmpty()) {
             bool const doNewEncoding = (Sci_HaveUndoRedoHistory() && !bSupressWarning) ?
-                                       IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO, L"MsgConv2", IDS_MUI_ASK_ENCODING2)) : true;
+                                       IsYesOkay(InfoBoxLng(MB_YESNO, L"MsgConv2", IDS_MUI_ASK_ENCODING2)) : true;
 
             if (doNewEncoding) {
                 return EditConvertText(hwnd, iCurrentEncoding, iNewEncoding);
@@ -572,7 +572,7 @@ bool EditSetNewEncoding(HWND hwnd, cpi_enc_t iNewEncoding, bool bSupressWarning)
                 bSupressWarning         = bIsCurANSI && bIsTargetUTF;
             }
 
-            bool const doNewEncoding = (!bSupressWarning) ? IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO, L"MsgConv1", IDS_MUI_ASK_ENCODING)) : true;
+            bool const doNewEncoding = (!bSupressWarning) ? IsYesOkay(InfoBoxLng(MB_YESNO, L"MsgConv1", IDS_MUI_ASK_ENCODING)) : true;
             if (doNewEncoding) {
                 return EditConvertText(hwnd, iCurrentEncoding, iNewEncoding);
             }
@@ -1216,7 +1216,7 @@ bool EditLoadFile(
         WCHAR sizeWarnStr[64] = { L'\0' };
         StrFormatByteSizeEx(fileSizeWarning, SFBS_FLAGS_ROUND_TO_NEAREST_DISPLAYED_DIGIT, sizeWarnStr, COUNTOF(sizeWarnStr));
         Flags.bHugeFileLoadState = true;
-        if (!IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO, L"MsgFileSizeWarning", IDS_MUI_WARN_LOAD_BIG_FILE, sizeStr, sizeWarnStr))) {
+        if (!IsYesOkay(InfoBoxLng(MB_YESNO, L"MsgFileSizeWarning", IDS_MUI_WARN_LOAD_BIG_FILE, sizeStr, sizeWarnStr))) {
             CloseHandle(hFile);
             Encoding_Forced(CPI_NONE);
             return false;
@@ -1226,7 +1226,7 @@ bool EditLoadFile(
     // check for unknown file/extension
     status->bUnknownExt = false;
     if (!Style_HasLexerForExt(hfile_pth)) {
-        if (!IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO, L"MsgFileUnknownExt", IDS_MUI_WARN_UNKNOWN_EXT, Path_FindFileName(hfile_pth)))) {
+        if (!IsYesOkay(InfoBoxLng(MB_YESNO, L"MsgFileUnknownExt", IDS_MUI_WARN_UNKNOWN_EXT, Path_FindFileName(hfile_pth)))) {
             CloseHandle(hFile);
             Encoding_Forced(CPI_NONE);
             status->bUnknownExt = true;
@@ -1253,7 +1253,7 @@ bool EditLoadFile(
     bool bReadSuccess = ((readFlag & DECRYPT_FATAL_ERROR) || (readFlag & DECRYPT_FREAD_FAILED)) ? false : true;
 
     if ((readFlag & DECRYPT_CANCELED_NO_PASS) || (readFlag & DECRYPT_WRONG_PASS)) {
-        bReadSuccess = IsYesOkayRetryContinue(InfoBoxLng(MB_OKCANCEL, L"MsgNoOrWrongPassphrase", IDS_MUI_NOPASS));
+        bReadSuccess = IsYesOkay(InfoBoxLng(MB_OKCANCEL, L"MsgNoOrWrongPassphrase", IDS_MUI_NOPASS));
         if (!bReadSuccess) {
             Encoding_Forced(CPI_NONE);
             FreeMem(lpData);
@@ -1623,7 +1623,7 @@ bool EditSaveFile(
 
                     FreeMem(lpDataWide);
 
-                    if (!bCancelDataLoss || IsYesOkayRetryContinue(InfoBoxLng(MB_OKCANCEL, L"MsgConv3", IDS_MUI_ERR_UNICODE2))) {
+                    if (!bCancelDataLoss || IsYesOkay(InfoBoxLng(MB_OKCANCEL, L"MsgConv3", IDS_MUI_ERR_UNICODE2))) {
                         SetEndOfFile(hFile);
                         if (cbDataConverted != 0) {
                             bWriteSuccess = EncryptAndWriteFile(hwnd, hFile, (BYTE *)lpData, cbDataConverted, &bytesWritten);
@@ -7082,7 +7082,7 @@ bool EditFindNext(HWND hwnd, const LPEDITFINDREPLACE lpefr, bool bExtendSelectio
                 }
             } else {
                 LONG const result = InfoBoxLng(MB_OKCANCEL, L"MsgFindWrap1", IDS_MUI_FIND_WRAPFW);
-                if (!IsYesOkayRetryContinue(result)) {
+                if (!IsYesOkay(result)) {
                     iPos = -1LL;
                     bSuppressNotFound = true;
                 }
@@ -7171,7 +7171,7 @@ bool EditFindPrev(HWND hwnd, LPEDITFINDREPLACE lpefr, bool bExtendSelection, boo
                 }
             } else {
                 LONG const result = InfoBoxLng(MB_OKCANCEL, L"MsgFindWrap2", IDS_MUI_FIND_WRAPRE);
-                if (!IsYesOkayRetryContinue(result)) {
+                if (!IsYesOkay(result)) {
                     iPos = -1LL;
                     bSuppressNotFound = true;
                 }
@@ -7861,7 +7861,8 @@ bool EditAutoCompleteWord(HWND hwnd, bool autoInsert)
         ft.lpstrText = pRoot;
         ft.chrg.cpMax = (DocPosCR)iDocEndPos;
 
-        DocPos iPosFind = SciCall_FindTextFull(SCFIND_WORDSTART, &ft);
+        //DocPos iPosFind = SciCall_FindTextFull(SCFIND_WORDSTART, &ft);
+        DocPos iPosFind = SciCall_FindText(SCFIND_WORDSTART, &ft);
         PWLIST pwlNewWord = NULL;
 
         while ((iPosFind >= 0) && ((iPosFind + iRootLen) < iDocEndPos)) {
@@ -7895,7 +7896,8 @@ bool EditAutoCompleteWord(HWND hwnd, bool autoInsert)
             }
 
             ft.chrg.cpMin = (DocPosCR)iWordEndPos;
-            iPosFind = SciCall_FindTextFull(SCFIND_WORDSTART, &ft);
+            //iPosFind = SciCall_FindTextFull(SCFIND_WORDSTART, &ft);
+            iPosFind = SciCall_FindText(SCFIND_WORDSTART, &ft);
         }
         FreeMem(pwlNewWord);
         pwlNewWord = NULL;
@@ -8418,9 +8420,15 @@ bool EditLinenumDlg(HWND hwnd)
 //
 //  EditModifyLinesDlg()
 //
-//  Controls: 100 Input
-//            101 Input
-//
+//  Controls: 100 Input IDC_MODLNS_ED_PREPEND
+//            101 Input IDC_MODLNS_ED_APPEND
+//            IDC_MODLNS_DOCLN_CANONIC 200
+//            IDC_MODLNS_DOCLN_ZEROFLD 201
+//            IDC_MODLNS_CNTLN1_CANONIC 202
+//            IDC_MODLNS_CNTLN1_ZEROFLD 203
+//            IDC_MODLNS_CNTLN0_CANONIC 204
+//            IDC_MODLNS_CNTLN0_ZEROFLD 205
+
 static INT_PTR CALLBACK EditModifyLinesDlgProc(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
 {
 
@@ -8450,7 +8458,7 @@ static INT_PTR CALLBACK EditModifyLinesDlgProc(HWND hwnd, UINT umsg, WPARAM wPar
         }
 #endif
 
-        HFONT const hFont = (HFONT)SendDlgItemMessage(hwnd, 200, WM_GETFONT, 0, 0);
+        HFONT const hFont = (HFONT)SendDlgItemMessage(hwnd, IDC_MODLNS_DOCLN_CANONIC, WM_GETFONT, 0, 0);
         if (hFont) {
             LOGFONT lf = { 0 };
             GetObject(hFont, sizeof(LOGFONT), &lf);
@@ -8468,16 +8476,16 @@ static INT_PTR CALLBACK EditModifyLinesDlgProc(HWND hwnd, UINT umsg, WPARAM wPar
             hCursorHover = LoadCursor(Globals.hInstance, IDC_ARROW);
         }
         pData = (PENCLOSESELDATA)lParam;
-        SetDlgItemTextW(hwnd,100,pData->pwsz1);
-        SendDlgItemMessage(hwnd, 100, EM_LIMITTEXT, ENCLDATA_SIZE - 1, 0);
-        SetDlgItemTextW(hwnd,101,pData->pwsz2);
-        SendDlgItemMessage(hwnd, 101, EM_LIMITTEXT, ENCLDATA_SIZE - 1, 0);
+        SetDlgItemTextW(hwnd,IDC_MODLNS_ED_PREPEND, pData->pwsz1);
+        SendDlgItemMessage(hwnd,IDC_MODLNS_ED_PREPEND, EM_LIMITTEXT, ENCLDATA_SIZE - 1, 0);
+        SetDlgItemTextW(hwnd,IDC_MODLNS_ED_APPEND, pData->pwsz2);
+        SendDlgItemMessage(hwnd,IDC_MODLNS_ED_APPEND, EM_LIMITTEXT, ENCLDATA_SIZE - 1, 0);
         CenterDlgInParent(hwnd, NULL);
     }
     return true;
 
     case WM_DPICHANGED: {
-        HFONT const hFont = (HFONT)SendDlgItemMessage(hwnd, 200, WM_GETFONT, 0, 0);
+        HFONT const hFont = (HFONT)SendDlgItemMessage(hwnd, IDC_MODLNS_DOCLN_CANONIC, WM_GETFONT, 0, 0);
         if (hFont) {
             LOGFONT lf = { 0 };
             GetObject(hFont, sizeof(LOGFONT), &lf);
@@ -8511,11 +8519,11 @@ static INT_PTR CALLBACK EditModifyLinesDlgProc(HWND hwnd, UINT umsg, WPARAM wPar
 
 #ifdef D_NP3_WIN10_DARK_MODE
 
-CASE_WM_CTLCOLOR_SET: {
+    CASE_WM_CTLCOLOR_SET: {
             DWORD const dwId = GetWindowLong((HWND)lParam, GWL_ID);
             HDC const hdc = (HDC)wParam;
             INT_PTR const hbrReturn = SetDarkModeCtlColors(hdc, UseDarkMode());
-            if (dwId >= 200 && dwId <= 205) {
+            if (dwId >= IDC_MODLNS_DOCLN_CANONIC && dwId <= IDC_MODLNS_CNTLN0_ZEROFLD) {
                 SetBkMode(hdc, TRANSPARENT);
                 if (GetSysColorBrush(COLOR_HOTLIGHT)) {
                     SetTextColor(hdc, GetSysColor(COLOR_HOTLIGHT));
@@ -8558,10 +8566,11 @@ CASE_WM_CTLCOLOR_SET: {
         pt.x = LOWORD(lParam);
         pt.y = HIWORD(lParam);
         HWND hwndHover = ChildWindowFromPoint(hwnd,pt);
+
         DWORD dwId = (DWORD)GetWindowLong(hwndHover,GWL_ID);
 
         if (GetActiveWindow() == hwnd) {
-            if (dwId >= 200 && dwId <= 205) {
+            if (dwId >= IDC_MODLNS_DOCLN_CANONIC && dwId <= IDC_MODLNS_CNTLN0_ZEROFLD) {
                 if (id_capture == (int)dwId || id_capture == 0) {
                     if (id_hover != id_capture || id_hover == 0) {
                         id_hover = (int)dwId;
@@ -8584,7 +8593,7 @@ CASE_WM_CTLCOLOR_SET: {
         HWND hwndHover = ChildWindowFromPoint(hwnd,pt);
         DWORD dwId = GetWindowLong(hwndHover,GWL_ID);
 
-        if (dwId >= 200 && dwId <= 205) {
+        if (dwId >= IDC_MODLNS_DOCLN_CANONIC && dwId <= IDC_MODLNS_CNTLN0_ZEROFLD) {
             GetCapture();
             id_hover = dwId;
             id_capture = dwId;
@@ -8602,7 +8611,7 @@ CASE_WM_CTLCOLOR_SET: {
             ReleaseCapture();
             if (id_hover == id_capture) {
                 int id_focus = GetWindowLong(GetFocus(),GWL_ID);
-                if (id_focus == 100 || id_focus == 101) {
+                if (id_focus == IDC_MODLNS_ED_PREPEND || id_focus == IDC_MODLNS_ED_APPEND) {
                     WCHAR wch[8];
                     GetDlgItemText(hwnd,id_capture,wch,COUNTOF(wch));
                     SendDlgItemMessage(hwnd,id_focus,EM_SETSEL,(WPARAM)0,(LPARAM)-1);
@@ -8628,8 +8637,8 @@ CASE_WM_CTLCOLOR_SET: {
     case WM_COMMAND:
         switch(LOWORD(wParam)) {
         case IDOK: {
-            GetDlgItemTextW(hwnd, 100, pData->pwsz1, ENCLDATA_SIZE);
-            GetDlgItemTextW(hwnd, 101, pData->pwsz2, ENCLDATA_SIZE);
+            GetDlgItemTextW(hwnd, IDC_MODLNS_ED_PREPEND, pData->pwsz1, ENCLDATA_SIZE);
+            GetDlgItemTextW(hwnd, IDC_MODLNS_ED_APPEND, pData->pwsz2, ENCLDATA_SIZE);
             EndDialog(hwnd,IDOK);
         }
         break;

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -3756,7 +3756,7 @@ LRESULT MsgFileChangeNotify(HWND hwnd, WPARAM wParam, LPARAM lParam)
 
         if (!bRevertFile) {
             if (FileWatching.FileWatchingMode == FWM_MSGBOX) {
-                bRevertFile = IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_FILECHANGENOTIFY));
+                bRevertFile = IsYesOkay(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_FILECHANGENOTIFY));
             } else {
                 // FWM_INDICATORSILENT: nothing todo here
             }
@@ -3775,7 +3775,7 @@ LRESULT MsgFileChangeNotify(HWND hwnd, WPARAM wParam, LPARAM lParam)
     } else {
 
         if (FileWatching.FileWatchingMode == FWM_MSGBOX) {
-            if (IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_FILECHANGENOTIFY2))) {
+            if (IsYesOkay(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_FILECHANGENOTIFY2))) {
                 FileSave(FSF_SaveAlways);
             } else {
                 SetSaveNeeded();
@@ -4371,7 +4371,7 @@ LRESULT MsgCommand(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
     bool const bIsThemesMenuCmd = ((iLoWParam >= IDM_THEMES_FACTORY_RESET) && (iLoWParam < (int)(IDM_THEMES_FACTORY_RESET + ThemeItems_CountOf())));
     if (bIsThemesMenuCmd) {
         if (iLoWParam == IDM_THEMES_FACTORY_RESET) {
-            if (!IsYesOkayRetryContinue(InfoBoxLng(MB_OKCANCEL | MB_ICONWARNING, L"MsgResetScheme", IDS_MUI_WARN_STYLE_RESET))) {
+            if (!IsYesOkay(InfoBoxLng(MB_OKCANCEL | MB_ICONWARNING, L"MsgResetScheme", IDS_MUI_WARN_STYLE_RESET))) {
                 return FALSE;
             }
         }
@@ -4428,7 +4428,7 @@ LRESULT MsgCommand(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
 
     case IDM_FILE_REVERT:
         if (IsDocumentModified()) {
-            if (!IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO | MB_ICONQUESTION, NULL, IDS_MUI_ASK_REVERT))) {
+            if (!IsYesOkay(InfoBoxLng(MB_YESNO | MB_ICONQUESTION, NULL, IDS_MUI_ASK_REVERT))) {
                 break;
             }
             //~ don't revert if no save needed
@@ -4761,7 +4761,7 @@ LRESULT MsgCommand(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
             cpi_enc_t iNewEncoding = Encoding_MapSignature(Encoding_GetCurrent());
 
             if (IsDocumentModified()) {
-                if (!IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO | MB_ICONQUESTION, NULL, IDS_MUI_ASK_RECODE))) {
+                if (!IsYesOkay(InfoBoxLng(MB_YESNO | MB_ICONQUESTION, NULL, IDS_MUI_ASK_RECODE))) {
                     break;
                 }
             }
@@ -6192,7 +6192,7 @@ LRESULT MsgCommand(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
 
     case IDM_VIEW_WIN_DARK_MODE: {
 
-        if (!IsYesOkayRetryContinue(InfoBoxLng(MB_OKCANCEL | MB_ICONWARNING, L"MsgResetScheme", IDS_MUI_WARN_STYLE_RESET))) {
+        if (!IsYesOkay(InfoBoxLng(MB_OKCANCEL | MB_ICONWARNING, L"MsgResetScheme", IDS_MUI_WARN_STYLE_RESET))) {
            break;
         }
 
@@ -8139,7 +8139,7 @@ inline static LRESULT _MsgNotifyLean(const SCNotification *const scn, bool* bMod
                 EditToggleView(Globals.hwndEdit);
             }
             else {
-                if (!IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO | MB_ICONINFORMATION, L"QuietKeepReadonlyLock", IDS_MUI_DOCUMENT_READONLY))) {
+                if (!IsYesOkay(InfoBoxLng(MB_YESNO | MB_ICONINFORMATION, L"QuietKeepReadonlyLock", IDS_MUI_DOCUMENT_READONLY))) {
                     SendWMCommand(Globals.hwndMain, IDM_VIEW_READONLY);
                 }
             }
@@ -8587,7 +8587,7 @@ LRESULT MsgNotify(HWND hwnd, WPARAM wParam, LPARAM lParam)
 
                     WCHAR wch[64] = {L'\0'};
                     GetLngString(msgid, wch, COUNTOF(wch));
-                    if (IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_WARN_NORMALIZE_EOLS, wch))) {
+                    if (IsYesOkay(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_WARN_NORMALIZE_EOLS, wch))) {
                         PostWMCommand(hwnd, eol_cmd);
                     }
                 }
@@ -10660,7 +10660,7 @@ bool FileLoad(const HPATHL hfile_pth, FileLoadFlags fLoadFlags)
             GetLngString(IDS_MUI_UNTITLED, szDisplayName, COUNTOF(szDisplayName));
             Path_GetDisplayName(szDisplayName, COUNTOF(szDisplayName), hopen_file, NULL, false); //~Path_FindFileName(hopen_file)
 
-            if (IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO | MB_ICONQUESTION, NULL, IDS_MUI_ASK_CREATE, szDisplayName))) {
+            if (IsYesOkay(InfoBoxLng(MB_YESNO | MB_ICONQUESTION, NULL, IDS_MUI_ASK_CREATE, szDisplayName))) {
                 bCreateFile = true;
             }
         }
@@ -11229,7 +11229,7 @@ bool FileSave(FileSaveFlags fSaveFlags)
             } else {
                 answer = InfoBoxLng(MB_YESNO | MB_ICONINFORMATION, L"ReloadExSavedCfg", IDS_MUI_RELOADSETTINGS, L"");
             }
-            if (IsYesOkayRetryContinue(answer)) {
+            if (IsYesOkay(answer)) {
                 DialogNewWindow(Globals.hwndMain, false, Paths.CurrentFile, NULL);
                 CloseApplication();
             }
@@ -11440,7 +11440,7 @@ bool ActivatePrevInst()
                 return true;
             }
             // IsWindowEnabled()
-            if (IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_ERR_PREVWINDISABLED))) {
+            if (IsYesOkay(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_ERR_PREVWINDISABLED))) {
                 return false;
             }
             return true;
@@ -11530,7 +11530,7 @@ bool ActivatePrevInst()
             return true;
         }
         // IsWindowEnabled()
-        return !IsYesOkayRetryContinue(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_ERR_PREVWINDISABLED));
+        return !IsYesOkay(InfoBoxLng(MB_YESNO | MB_ICONWARNING, NULL, IDS_MUI_ERR_PREVWINDISABLED));
     }
     return false;
 }

--- a/src/SciCall.h
+++ b/src/SciCall.h
@@ -330,6 +330,7 @@ DeclareSciCallV0(SelectionDuplicate, SELECTIONDUPLICATE);
 DeclareSciCallV0(LineTranspose, LINETRANSPOSE);
 DeclareSciCallV0(MoveSelectedLinesUp, MOVESELECTEDLINESUP);
 DeclareSciCallV0(MoveSelectedLinesDown, MOVESELECTEDLINESDOWN);
+DeclareSciCallR2(FindText, FINDTEXT, DocPos, int, flags, struct Sci_TextToFind*, text);
 DeclareSciCallR2(FindTextFull, FINDTEXTFULL, DocPos, int, flags, struct Sci_TextToFind*, text);
 
 // Operations

--- a/src/crypto/crypto.c
+++ b/src/crypto/crypto.c
@@ -570,7 +570,7 @@ int ReadAndDecryptFile(HWND hwnd, HANDLE hFile, size_t fileSize, void** result, 
                             }
                             else
                             {
-                                bRetryPassPhrase = IsYesOkayRetryContinue(InfoBoxLng(MB_RETRYCANCEL | MB_ICONWARNING, NULL, IDS_MUI_PASS_FAILURE));
+                                bRetryPassPhrase = IsRetryContinue(InfoBoxLng(MB_RETRYCANCEL | MB_ICONWARNING, NULL, IDS_MUI_PASS_FAILURE));
                                 if (!bRetryPassPhrase)
                                 {
                                     // enable raw encryption read


### PR DESCRIPTION
+chg: use deprecated SCI_FINDTEXT to workaround crash on new (Sci v5.2.3) SCI_FINDTEXTFULL method.