### PR TITLE
Caret style: allow std caret bar width up to max(20) and define alpha transparency (not below 20)

### DIFF
--- a/language/np3_de_de/lexer_de_de.rc
+++ b/language/np3_de_de/lexer_de_de.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colors)"
     IDS_LEX_STD_WSPC        "Whitespace (Colors, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Color, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Color, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colors)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2ter Standard Stil"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Color, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Color, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colors)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colors, Size)"

--- a/language/np3_el_gr/lexer_el_gr.rc
+++ b/language/np3_el_gr/lexer_el_gr.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colours)"
     IDS_LEX_STD_WSPC        "Whitespace (Colours, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colours)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2nd Default Style"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colours)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colours, Size)"

--- a/language/np3_en_gb/lexer_en_gb.rc
+++ b/language/np3_en_gb/lexer_en_gb.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colours)"
     IDS_LEX_STD_WSPC        "Whitespace (Colours, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colours)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2nd Default Style"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colours)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colours, Size)"

--- a/language/np3_en_us/lexer_en_us.rc
+++ b/language/np3_en_us/lexer_en_us.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colors)"
     IDS_LEX_STD_WSPC        "Whitespace (Colors, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Color, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Color, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colors)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2nd Default Style"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Color, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Color, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colors)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colors, Size)"

--- a/language/np3_es_es/lexer_es_es.rc
+++ b/language/np3_es_es/lexer_es_es.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colors)"
     IDS_LEX_STD_WSPC        "Whitespace (Colors, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Color, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Color, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colors)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2º Defecto Estilo"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Color, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Color, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colors)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colors, Size)"

--- a/language/np3_es_mx/lexer_es_mx.rc
+++ b/language/np3_es_mx/lexer_es_mx.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colors)"
     IDS_LEX_STD_WSPC        "Whitespace (Colors, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Color, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Color, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colors)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2º Defecto Estilo"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Color, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Color, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colors)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colors, Size)"

--- a/language/np3_fr_fr/lexer_fr_fr.rc
+++ b/language/np3_fr_fr/lexer_fr_fr.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colors)"
     IDS_LEX_STD_WSPC        "Whitespace (Colors, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Color, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Color, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colors)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2ème Style par Défaut"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Color, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Color, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colors)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colors, Size)"

--- a/language/np3_id_id/lexer_id_id.rc
+++ b/language/np3_id_id/lexer_id_id.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colours)"
     IDS_LEX_STD_WSPC        "Whitespace (Colours, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colours)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2nd Default Style"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colours)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colours, Size)"

--- a/language/np3_it_it/lexer_it_it.rc
+++ b/language/np3_it_it/lexer_it_it.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colours)"
     IDS_LEX_STD_WSPC        "Whitespace (Colours, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colours)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2nd Default Style"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colours)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colours, Size)"

--- a/language/np3_pl_pl/lexer_pl_pl.rc
+++ b/language/np3_pl_pl/lexer_pl_pl.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colours)"
     IDS_LEX_STD_WSPC        "Whitespace (Colours, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colours)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2nd Default Style"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colours)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colours, Size)"

--- a/language/np3_sk_sk/lexer_sk_sk.rc
+++ b/language/np3_sk_sk/lexer_sk_sk.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colours)"
     IDS_LEX_STD_WSPC        "Whitespace (Colours, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colours)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2nd Default Style"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colours)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colours, Size)"

--- a/language/np3_vi_vn/lexer_vi_vn.rc
+++ b/language/np3_vi_vn/lexer_vi_vn.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_LEX_STD_SEL         "Selected Text (Colours)"
     IDS_LEX_STD_WSPC        "Whitespace (Colours, Size 1-12)"
     IDS_LEX_STD_LN_BACKGR   "Highlight Current Line"
-    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-3)"
+    IDS_LEX_STD_CARET       "Caret (Colour, Size 1-20)"
     IDS_LEX_STD_LONG_LN     "Long Line Marker (Colours)"
     IDS_LEX_STD_X_SPC       "Extra Line Spacing (Size)"
     IDS_LEX_2ND_STYLE       "2nd Default Style"
@@ -163,7 +163,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_LEX_2ND_LN_BACKGR   "2nd Highlight Current Line"
-    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-3)"
+    IDS_LEX_2ND_CARET       "2nd Caret (Colour, Size 1-20)"
     IDS_LEX_2ND_LONG_LN     "2nd Long Line Marker (Colours)"
     IDS_LEX_2ND_X_SPC       "2nd Extra Line Spacing (Size)"
     IDS_LEX_STD_BKMRK       "Bookmarks and Folding (Colours, Size)"

--- a/lexilla/lexers_x/todo_lexers.txt
+++ b/lexilla/lexers_x/todo_lexers.txt
@@ -1,3 +1,30 @@
 Compare Homebrew with New Origin Lexers
 ----------------------------------------
 - LexerMarkdown.cxx
+Compare Homebrew with New Origin Lexers
+----------------------------------------
+- LexerMarkdown.cxx
+Compare Homebrew with New Origin Lexers
+----------------------------------------
+- LexerMarkdown.cxx
+Compare Homebrew with New Origin Lexers
+----------------------------------------
+- LexerMarkdown.cxx
+Compare Homebrew with New Origin Lexers
+----------------------------------------
+- LexerMarkdown.cxx
+Compare Homebrew with New Origin Lexers
+----------------------------------------
+- LexerMarkdown.cxx
+Compare Homebrew with New Origin Lexers
+----------------------------------------
+- LexerMarkdown.cxx
+Compare Homebrew with New Origin Lexers
+----------------------------------------
+- LexerMarkdown.cxx
+Compare Homebrew with New Origin Lexers
+----------------------------------------
+- LexerMarkdown.cxx
+Compare Homebrew with New Origin Lexers
+----------------------------------------
+- LexerMarkdown.cxx

--- a/src/Helpers.c
+++ b/src/Helpers.c
@@ -696,10 +696,8 @@ bool VerifyContrast(COLORREF cr1,COLORREF cr2)
     BYTE r2 = GetRValue(cr2);
     BYTE g2 = GetGValue(cr2);
     BYTE b2 = GetBValue(cr2);
-
-    return(
-              ((abs((3*r1 + 5*g1 + 1*b1) - (3*r2 + 6*g2 + 1*b2))) >= 400) ||
-              ((abs(r1-r2) + abs(b1-b2) + abs(g1-g2)) >= 400));
+    return (((abs((3*r1 + 5*g1 + 1*b1) - (3*r2 + 6*g2 + 1*b2))) >= 400) ||
+            ((abs(r1-r2) + abs(b1-b2) + abs(g1-g2)) >= 400));
 }
 
 

--- a/src/Styles.c
+++ b/src/Styles.c
@@ -1607,7 +1607,7 @@ void Style_SetLexer(HWND hwnd, PEDITLEXER pLexNew)
         iValue = 1; // don't allow invisible 0
         fValue = 0.0f;
         if (Style_StrGetSizeFloat(pCurrentStandard->Styles[STY_CARET].szValue, &fValue)) {
-            iValue = clampi(f2int(fValue), 1, 3);
+            iValue = clampi(f2int(fValue), 1, 20);
             if (iValue != 1) {
                 StringCchPrintf(wch, COUNTOF(wch), L"; size:%i", iValue);
                 StringCchCat(wchSpecificStyle, COUNTOF(wchSpecificStyle), wch);
@@ -1639,8 +1639,13 @@ void Style_SetLexer(HWND hwnd, PEDITLEXER pLexNew)
         rgb = SciCall_StyleGetFore(0);
     }
 
-    SciCall_SetElementColour(SC_ELEMENT_CARET, RGBxA(rgb, SC_ALPHA_OPAQUE));
-    SciCall_SetElementColour(SC_ELEMENT_CARET_ADDITIONAL, RGBxA(RGB(220, 0, 0), SC_ALPHA_OPAQUE));
+    if (Style_StrGetAlpha(pCurrentStandard->Styles[STY_CARET].szValue, &iValue, true)) {
+        iValue = clampi(iValue, 20, SC_ALPHA_OPAQUE); // no full transparency
+        StringCchPrintf(wch, COUNTOF(wch), L"; alpha:%i", iValue);
+        StringCchCat(wchSpecificStyle, COUNTOF(wchSpecificStyle), wch);
+    }
+    SciCall_SetElementColour(SC_ELEMENT_CARET, RGBxA(rgb, iValue));
+    SciCall_SetElementColour(SC_ELEMENT_CARET_ADDITIONAL, RGBxA(RGB(220, 0, 0), iValue));
 
     StrTrim(wchSpecificStyle, L" ;");
     StringCchCopy(pCurrentStandard->Styles[STY_CARET].szValue,


### PR DESCRIPTION
ref. issue #4106