### PR TITLE
Update translation for zh_CN and zh_TW

### DIFF
--- a/language/np3_zh_cn/menu_zh_cn.rc
+++ b/language/np3_zh_cn/menu_zh_cn.rc
@@ -469,7 +469,7 @@ BEGIN
         MENUITEM "自动换行设置(&W)...",                         IDM_SET_WORDWRAPSETTINGS
         MENUITEM "长行标记设置(&O)...",                         IDM_SET_LONGLINESETTINGS
         MENUITEM "自动缩进(&D)",                                IDM_SET_AUTOINDENTTEXT
-        MENUITEM "Auto Close Brackets",                      IDM_SET_AUTOCLOSEBRACKETS
+        MENUITEM "自动关闭括号(&L)",                      IDM_SET_AUTOCLOSEBRACKETS
         MENUITEM "自动关闭 &HTML/XML 标记\tCtrl+Shift+H",       IDM_SET_AUTOCLOSETAGS
         MENUITEM "自动补全单词(&U)",                            IDM_SET_AUTOCOMPLETEWORDS
         MENUITEM "自动补全语法关键字(&K)",                      IDM_SET_AUTOCLEXKEYWORDS

--- a/language/np3_zh_tw/menu_zh_tw.rc
+++ b/language/np3_zh_tw/menu_zh_tw.rc
@@ -469,7 +469,7 @@ BEGIN
         MENUITEM "自動換行設定(&W)...",                         IDM_SET_WORDWRAPSETTINGS
         MENUITEM "長行標記設定(&O)...",                         IDM_SET_LONGLINESETTINGS
         MENUITEM "自動縮排(&D)",                                IDM_SET_AUTOINDENTTEXT
-        MENUITEM "Auto Close Brackets",                      IDM_SET_AUTOCLOSEBRACKETS
+        MENUITEM "自動關閉括弧(&L)",                      IDM_SET_AUTOCLOSEBRACKETS
         MENUITEM "自動關閉 HTML/XML 標記(&H)\tCtrl+Shift+H",       IDM_SET_AUTOCLOSETAGS
         MENUITEM "自動完成單詞(&U)",                            IDM_SET_AUTOCOMPLETEWORDS
         MENUITEM "自動完成語法關鍵字(&K)",                      IDM_SET_AUTOCLEXKEYWORDS


### PR DESCRIPTION
This new menu element lacks a shortcut. I think `Auto C&lose Brackets` would be good.