### PR TITLE
Roll back the naming of Traditional Chinese to the international standard

### DIFF
--- a/grepWinNP3/translationsNP3/繁體中文 (中國台灣) [zh-TW].lang
+++ b/grepWinNP3/translationsNP3/繁體中文 (中國台灣) [zh-TW].lang
@@ -9,7 +9,7 @@
 #
 # encoding: UTF-8
 # Language: Chinese Traditional (Taiwan, China) resources
-# Translator: (zh-TW) 正體中文翻譯 by lhmouse
+# Translator: (zh-TW) 繁體中文翻譯 by lhmouse
 #
 
 #, fuzzy

--- a/language/np3_zh_tw/encode_zh_tw.rc
+++ b/language/np3_zh_tw/encode_zh_tw.rc
@@ -83,8 +83,8 @@ BEGIN
     IDS_ENC_GBK_936                "C;簡體中文 (GBK);GBK"
     IDS_ENC_GB2312_80              "C;簡體中文 Simplified (GB_2312-80);GB_2312-80"
     IDS_ENC_MAC_ZH_CN              "C;簡體中文 (Mac);Mac (zh-cn)"
-    IDS_ENC_BIG5                   "C;正體中文 (Big5);Big5"
-    IDS_ENC_MAC_ZH_TW              "C;正體中文 (Mac);Mac (zh-tw)"
+    IDS_ENC_BIG5                   "C;繁體中文 (Big5);Big5"
+    IDS_ENC_MAC_ZH_TW              "C;繁體中文 (Mac);Mac (zh-tw)"
 END
 
 STRINGTABLE
@@ -151,11 +151,11 @@ STRINGTABLE
 BEGIN
     IDS_ENC_EUC_JAPANESE           "C;日文 (EUC-JP);EUC-JP"
     IDS_ENC_EUC_KOREAN             "C;韓文 (EUC-KR);EUC-KR"
-    IDS_ENC_ISO_2022_CN            "C;正體中文 (ISO-2022-CN);ISO-2022-CN"
+    IDS_ENC_ISO_2022_CN            "C;繁體中文 (ISO-2022-CN);ISO-2022-CN"
     IDS_ENC_HZ_GB2312              "C;簡體中文 (HZ-GB-2312);HZ-GB-2312"
     IDS_ENC_ISO_2022_JP            "C;日文 (ISO-2022-JP);ISO-2022-JP"
     IDS_ENC_ISO_2022_KR            "C;韓文 (ISO-2022-KR);ISO-2022-KR"
-    IDS_ENC_X_CHINESE_CNS          "C;正體中文 (CNS);x-Chinese-CNS"
+    IDS_ENC_X_CHINESE_CNS          "C;繁體中文 (CNS);x-Chinese-CNS"
     IDS_ENC_JOHAB                  "C;韓文 (Johab);韓文 (Johab)"
     IDS_ENC_ISO_8859_10            "B;北歐 (ISO-8859-10);ISO-8859-10"
     IDS_ENC_BIG5_HKSCS             "C;簡體中文 (Big5-HKSCS);Big5-HKSCS"

--- a/language/np3_zh_tw/strings_zh_tw.rc
+++ b/language/np3_zh_tw/strings_zh_tw.rc
@@ -247,7 +247,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_MUI_TRANSL_AUTHOR   "(zh-TW) 正體中文翻譯 by lhmouse"
+    IDS_MUI_TRANSL_AUTHOR   "(zh-TW) 繁體中文翻譯 by lhmouse"
     IDS_MUI_TITLE_FIXBASE   "BASE (%s)"
     IDS_MUI_TITLE_RELCUR    "+++ %s: %s Style +++"
     IDS_MUI_TITLE_FIXCUR    "%s: %s Style"

--- a/minipath/language/mp_zh_tw/strings_zh_tw.rc
+++ b/minipath/language/mp_zh_tw/strings_zh_tw.rc
@@ -132,7 +132,7 @@ BEGIN
     IDS_COPYMOVE            "選擇目的地目錄。"
     IDS_CREATELINK          "為新連結選擇目的地目錄。"
     IDS_SAVESETTINGS        "儲存設定\n目前程式設定已儲存。"
-    IDS_MUI_TRANSL_AUTHOR   "(zh-TW) 正體中文翻譯 by lhmouse"
+    IDS_MUI_TRANSL_AUTHOR   "(zh-TW) 繁體中文翻譯 by lhmouse"
 END
 
 

--- a/src/MuiLanguage.c
+++ b/src/MuiLanguage.c
@@ -81,7 +81,7 @@ grepWinLng_t grepWinLangResName[] = {
     { L"tr-TR",  L".\\lng\\gwLng\\Türkçe (Türkiye) [tr-TR].lang" },
     { L"vi-VN",  L".\\lng\\gwLng\\Tiếng Việt (Việt Nam) [vi-VN].lang" },
     { L"zh-CN",  L".\\lng\\gwLng\\简体中文 (中国大陆) [zh-CN].lang" },
-    { L"zh-TW",  L".\\lng\\gwLng\\正體中文 (中國台灣) [zh-TW].lang" }
+    { L"zh-TW",  L".\\lng\\gwLng\\繁體中文 (中國台灣) [zh-TW].lang" }
 };
 
 unsigned grepWinLang_CountOf() {
@@ -234,7 +234,7 @@ MUILANGUAGE MUI_LanguageDLLs[] = {
     { IDS_MUI_LANG_TR_TR,  L"tr-TR",   L"Türkçe (Türkiye)\t\t\t[%s]",              false, false },
     { IDS_MUI_LANG_VI_VN,  L"vi-VN",   L"Tiếng Việt (Việt Nam)\t\t\t[%s]",         false, false },
     { IDS_MUI_LANG_ZH_CN,  L"zh-CN",   L"简体中文 (中国大陆)\t\t\t[%s]",                false, false },
-    { IDS_MUI_LANG_ZH_TW,  L"zh-TW",   L"正體中文 (中國台灣)\t\t\t[%s]",                false, false }
+    { IDS_MUI_LANG_ZH_TW,  L"zh-TW",   L"繁體中文 (中國台灣)\t\t\t[%s]",                false, false }
 };
 
 //NUM_OF_MUI_LANGUAGES


### PR DESCRIPTION
This is a hidden historical problem. I checked the update record and found the disputed content was added after a translation in Jul 7, 2021.