### PR TITLE
Fix: don't reset "dirty flag" after file loading

### DIFF
--- a/scintilla/Scintilla.vcxproj
+++ b/scintilla/Scintilla.vcxproj
@@ -341,6 +341,7 @@
     <ClCompile Include="oniguruma\src\regenc.c" />
     <ClCompile Include="oniguruma\src\regerror.c" />
     <ClCompile Include="oniguruma\src\regexec.c" />
+    <ClCompile Include="oniguruma\src\regext.c" />
     <ClCompile Include="oniguruma\src\reggnu.c" />
     <ClCompile Include="oniguruma\src\regparse.c" />
     <ClCompile Include="oniguruma\src\regsyntax.c" />

--- a/scintilla/Scintilla.vcxproj.filters
+++ b/scintilla/Scintilla.vcxproj.filters
@@ -183,6 +183,9 @@
     <ClCompile Include="src\ChangeHistory.cxx">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="oniguruma\src\regext.c">
+      <Filter>oniguruma\src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\ILexer.h">

--- a/scintilla/oniguruma/src/ascii.c
+++ b/scintilla/oniguruma/src/ascii.c
@@ -146,8 +146,8 @@ OnigEncodingType OnigEncodingASCII_CR = {
 OnigEncodingType OnigEncodingASCII_CRLF = {
   onigenc_single_byte_mbc_enc_len,
   "US-ASCII",  /* name */
-  1,           /* max enc length */
-  1,           /* min enc length */
+  2,           /* max enc length */
+  2,           /* min enc length */
   onigenc_is_mbc_newline_0x0d_0x0a,
   onigenc_single_byte_mbc_to_code,
   onigenc_single_byte_code_to_mbclen,

--- a/scintilla/oniguruma/src/make_unicode_property_data.py
+++ b/scintilla/oniguruma/src/make_unicode_property_data.py
@@ -7,7 +7,7 @@ import sys
 import re
 
 POSIX_LIST = [
-    'NEWLINE', 'Alpha', 'Blank', 'Cntrl', 'Digit', 'Graph', 'Lower',
+  'NEWLINE', 'Alpha', 'Blank', 'Cntrl', 'Digit', 'Graph', 'Lower',
   'Print', 'PosixPunct', 'Space', 'Upper', 'XDigit', 'Word', 'Alnum',
   'ASCII'
 ]

--- a/scintilla/oniguruma/src/oniguruma.h
+++ b/scintilla/oniguruma/src/oniguruma.h
@@ -195,9 +195,8 @@ ONIG_EXTERN OnigEncodingType OnigEncodingUTF8_CR;
 ONIG_EXTERN OnigEncodingType OnigEncodingUTF8_CRLF;
 #endif
 
+#if 0
 #define ONIG_ENCODING_ASCII        (&OnigEncodingASCII)
-#define ONIG_ENCODING_ASCII_CR     (&OnigEncodingASCII_CR)
-#define ONIG_ENCODING_ASCII_CRLF   (&OnigEncodingASCII_CRLF)
 #define ONIG_ENCODING_ISO_8859_1   (&OnigEncodingISO_8859_1)
 #define ONIG_ENCODING_ISO_8859_2   (&OnigEncodingISO_8859_2)
 #define ONIG_ENCODING_ISO_8859_3   (&OnigEncodingISO_8859_3)
@@ -214,8 +213,6 @@ ONIG_EXTERN OnigEncodingType OnigEncodingUTF8_CRLF;
 #define ONIG_ENCODING_ISO_8859_15  (&OnigEncodingISO_8859_15)
 #define ONIG_ENCODING_ISO_8859_16  (&OnigEncodingISO_8859_16)
 #define ONIG_ENCODING_UTF8         (&OnigEncodingUTF8)
-#define ONIG_ENCODING_UTF8_CR      (&OnigEncodingUTF8_CR)
-#define ONIG_ENCODING_UTF8_CRLF    (&OnigEncodingUTF8_CRLF)
 #define ONIG_ENCODING_UTF16_BE     (&OnigEncodingUTF16_BE)
 #define ONIG_ENCODING_UTF16_LE     (&OnigEncodingUTF16_LE)
 #define ONIG_ENCODING_UTF32_BE     (&OnigEncodingUTF32_BE)
@@ -230,6 +227,14 @@ ONIG_EXTERN OnigEncodingType OnigEncodingUTF8_CRLF;
 #define ONIG_ENCODING_CP1251       (&OnigEncodingCP1251)
 #define ONIG_ENCODING_BIG5         (&OnigEncodingBIG5)
 #define ONIG_ENCODING_GB18030      (&OnigEncodingGB18030)
+#else // lean and mean
+#define ONIG_ENCODING_ASCII        (&OnigEncodingASCII)
+#define ONIG_ENCODING_ASCII_CR     (&OnigEncodingASCII_CR)
+#define ONIG_ENCODING_ASCII_CRLF   (&OnigEncodingASCII_CRLF)
+#define ONIG_ENCODING_UTF8         (&OnigEncodingUTF8)
+#define ONIG_ENCODING_UTF8_CR      (&OnigEncodingUTF8_CR)
+#define ONIG_ENCODING_UTF8_CRLF    (&OnigEncodingUTF8_CRLF)
+#endif
 
 #define ONIG_ENCODING_UNDEF    ((OnigEncoding )0)
 

--- a/scintilla/oniguruma/src/regcomp.c
+++ b/scintilla/oniguruma/src/regcomp.c
@@ -7076,7 +7076,7 @@ clear_optimize_info(regex_t* reg)
 
 static void
 print_enc_string(FILE* fp, OnigEncoding enc,
-                             const UChar *s, const UChar *end)
+                 const UChar *s, const UChar *end)
 {
   if (ONIGENC_MBC_MINLEN(enc) > 1) {
     const UChar *p;
@@ -7106,7 +7106,7 @@ print_enc_string(FILE* fp, OnigEncoding enc,
         }
       }
       else { /* for UTF-8 */
-      fputc((int )*s, fp);
+        fputc((int )*s, fp);
       }
       s++;
     }
@@ -7251,7 +7251,7 @@ print_optimize_info(FILE* f, regex_t* reg)
       if (reg->map[i]) n++;
 
     fprintf(f, "map: n=%d, dmin: %u, dmax: %u\n",
-               n, reg->dist_min, reg->dist_max);
+            n, reg->dist_min, reg->dist_max);
     if (n > 0) {
       c = 0;
       fputc('[', f);

--- a/scintilla/oniguruma/src/regenc.c
+++ b/scintilla/oniguruma/src/regenc.c
@@ -719,8 +719,7 @@ extern int
 onigenc_is_mbc_newline_0x0d_0x0a(const UChar* p, const UChar* end)
 {
   if (p < end) {
-    //~if ((*p == CARRIAGE_RET) && (*(p+1) == NEWLINE_CODE)) return 1; // CRLF
-    if ((*p == NEWLINE_CODE) || (*p == CARRIAGE_RET)) return 1; // LF|CR
+    if ((*p == CARRIAGE_RET) && (*(p+1) == NEWLINE_CODE)) return 1; // CRLF
   }
   return 0;
 }

--- a/scintilla/oniguruma/src/regexec.c
+++ b/scintilla/oniguruma/src/regexec.c
@@ -3059,7 +3059,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       }
 
 #ifdef USE_FIND_LONGEST_SEARCH_ALL_OF_RANGE
-        if (OPTON_FIND_LONGEST(options)) {
+      if (OPTON_FIND_LONGEST(options)) {
         if (n > best_len) {
           if (n > msa->best_len) {
             best_len = n;
@@ -3080,10 +3080,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
         }
       }
       else {
-          best_len = n;
-        }
-#else
         best_len = n;
+      }
+#else
+      best_len = n;
 #endif
 
       /* set region */
@@ -4656,8 +4656,8 @@ regset_search_body_position_lead(OnigRegSet* set,
 
 static inline int
 regset_search_body_regex_lead(OnigRegSet* set,
-            const UChar* str, const UChar* end,
-            const UChar* start, const UChar* orig_range, OnigRegSetLead lead,
+              const UChar* str, const UChar* end,
+              const UChar* start, const UChar* orig_range, OnigRegSetLead lead,
               OnigOptionType option, OnigMatchParam* mps[], int* rmatch_pos)
 {
   int r;
@@ -4828,9 +4828,9 @@ onig_regset_search_with_param(OnigRegSet* set,
             goto match;
           }
           else goto finish; /* error */
-          }
         }
       }
+    }
 
     goto mismatch;
   }
@@ -4890,7 +4890,7 @@ onig_regset_search_with_param(OnigRegSet* set,
 
 extern int
 onig_regset_search(OnigRegSet* set, const UChar* str, const UChar* end,
-             const UChar* start, const UChar* range,
+                   const UChar* start, const UChar* range,
                    OnigRegSetLead lead, OnigOptionType option, int* rmatch_pos)
 {
   int r;

--- a/scintilla/oniguruma/src/regext.c
+++ b/scintilla/oniguruma/src/regext.c
@@ -1,0 +1,202 @@
+/**********************************************************************
+  regext.c -  Oniguruma (regular expression library)
+**********************************************************************/
+/*-
+ * Copyright (c) 2002-2019  K.Kosako
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "regint.h"
+
+#if 0
+static void
+conv_ext0be32(const UChar* s, const UChar* end, UChar* conv)
+{
+  while (s < end) {
+    *conv++ = '\0';
+    *conv++ = '\0';
+    *conv++ = '\0';
+    *conv++ = *s++;
+  }
+}
+
+static void
+conv_ext0le32(const UChar* s, const UChar* end, UChar* conv)
+{
+  while (s < end) {
+    *conv++ = *s++;
+    *conv++ = '\0';
+    *conv++ = '\0';
+    *conv++ = '\0';
+  }
+}
+
+static void
+conv_ext0be(const UChar* s, const UChar* end, UChar* conv)
+{
+  while (s < end) {
+    *conv++ = '\0';
+    *conv++ = *s++;
+  }
+}
+
+static void
+conv_ext0le(const UChar* s, const UChar* end, UChar* conv)
+{
+  while (s < end) {
+    *conv++ = *s++;
+    *conv++ = '\0';
+  }
+}
+
+static void
+conv_swap4bytes(const UChar* s, const UChar* end, UChar* conv)
+{
+  while (s < end) {
+    *conv++ = s[3];
+    *conv++ = s[2];
+    *conv++ = s[1];
+    *conv++ = s[0];
+    s += 4;
+  }
+}
+
+static void
+conv_swap2bytes(const UChar* s, const UChar* end, UChar* conv)
+{
+  while (s < end) {
+    *conv++ = s[1];
+    *conv++ = s[0];
+    s += 2;
+  }
+}
+
+static int
+conv_encoding(OnigEncoding from, OnigEncoding to, const UChar* s, const UChar* end,
+              UChar** conv, UChar** conv_end)
+{
+  int len = (int )(end - s);
+
+  if (to == ONIG_ENCODING_UTF16_BE) {
+    if (from == ONIG_ENCODING_ASCII || from == ONIG_ENCODING_ISO_8859_1) {
+      *conv = (UChar* )xmalloc(len * 2);
+      CHECK_NULL_RETURN_MEMERR(*conv);
+      *conv_end = *conv + (len * 2);
+      conv_ext0be(s, end, *conv);
+      return 0;
+    }
+    else if (from == ONIG_ENCODING_UTF16_LE) {
+    swap16:
+      *conv = (UChar* )xmalloc(len);
+      CHECK_NULL_RETURN_MEMERR(*conv);
+      *conv_end = *conv + len;
+      conv_swap2bytes(s, end, *conv);
+      return 0;
+    }
+  }
+  else if (to == ONIG_ENCODING_UTF16_LE) {
+    if (from == ONIG_ENCODING_ASCII || from == ONIG_ENCODING_ISO_8859_1) {
+      *conv = (UChar* )xmalloc(len * 2);
+      CHECK_NULL_RETURN_MEMERR(*conv);
+      *conv_end = *conv + (len * 2);
+      conv_ext0le(s, end, *conv);
+      return 0;
+    }
+    else if (from == ONIG_ENCODING_UTF16_BE) {
+      goto swap16;
+    }
+  }
+  if (to == ONIG_ENCODING_UTF32_BE) {
+    if (from == ONIG_ENCODING_ASCII || from == ONIG_ENCODING_ISO_8859_1) {
+      *conv = (UChar* )xmalloc(len * 4);
+      CHECK_NULL_RETURN_MEMERR(*conv);
+      *conv_end = *conv + (len * 4);
+      conv_ext0be32(s, end, *conv);
+      return 0;
+    }
+    else if (from == ONIG_ENCODING_UTF32_LE) {
+    swap32:
+      *conv = (UChar* )xmalloc(len);
+      CHECK_NULL_RETURN_MEMERR(*conv);
+      *conv_end = *conv + len;
+      conv_swap4bytes(s, end, *conv);
+      return 0;
+    }
+  }
+  else if (to == ONIG_ENCODING_UTF32_LE) {
+    if (from == ONIG_ENCODING_ASCII || from == ONIG_ENCODING_ISO_8859_1) {
+      *conv = (UChar* )xmalloc(len * 4);
+      CHECK_NULL_RETURN_MEMERR(*conv);
+      *conv_end = *conv + (len * 4);
+      conv_ext0le32(s, end, *conv);
+      return 0;
+    }
+    else if (from == ONIG_ENCODING_UTF32_BE) {
+      goto swap32;
+    }
+  }
+
+  return ONIGERR_NOT_SUPPORTED_ENCODING_COMBINATION;
+}
+#endif
+
+extern int
+onig_new_deluxe(regex_t** reg, const UChar* pattern, const UChar* pattern_end,
+                OnigCompileInfo* ci, OnigErrorInfo* einfo)
+{
+  int r;
+  UChar *cpat, *cpat_end;
+
+  if (IS_NOT_NULL(einfo)) einfo->par = (UChar* )NULL;
+
+  if (ci->pattern_enc != ci->target_enc) {
+    return ONIGERR_NOT_SUPPORTED_ENCODING_COMBINATION;
+  }
+  else {
+    cpat     = (UChar* )pattern;
+    cpat_end = (UChar* )pattern_end;
+  }
+
+  *reg = (regex_t* )xmalloc(sizeof(regex_t));
+  if (IS_NULL(*reg)) {
+    r = ONIGERR_MEMORY;
+    goto err2;
+  }
+
+  r = onig_reg_init(*reg, ci->option, ci->case_fold_flag, ci->target_enc,
+                    ci->syntax);
+  if (r != 0) goto err;
+
+  r = onig_compile(*reg, cpat, cpat_end, einfo);
+  if (r != 0) {
+  err:
+    onig_free(*reg);
+    *reg = NULL;
+  }
+
+ err2:
+  if (cpat != pattern) xfree(cpat);
+
+  return r;
+}

--- a/scintilla/oniguruma/src/regparse.c
+++ b/scintilla/oniguruma/src/regparse.c
@@ -5172,10 +5172,10 @@ is_posix_bracket_start(UChar* from, UChar* to, OnigEncoding enc)
   p = from;
   while (p < to) {
     x = ONIGENC_MBC_TO_CODE(enc, p, to);
-      p += enclen(enc, p);
+    p += enclen(enc, p);
     if (x == ':') {
       if (p < to) {
-      x = ONIGENC_MBC_TO_CODE(enc, p, to);
+        x = ONIGENC_MBC_TO_CODE(enc, p, to);
         if (x == ']') {
           if (n == 0) return FALSE;
           else        return TRUE;
@@ -5183,13 +5183,13 @@ is_posix_bracket_start(UChar* from, UChar* to, OnigEncoding enc)
       }
 
       return FALSE;
-      }
+    }
     else if (x == '^' && n == 0) {
       ;
     }
     else if (! ONIGENC_IS_CODE_ALPHA(enc, x)) {
       break;
-  }
+    }
 
     n += 1;
   }
@@ -6666,8 +6666,8 @@ prs_posix_bracket(CClassNode* cc, UChar** src, UChar* end, ParseEnv* env)
     }
   }
 
-        return ONIGERR_INVALID_POSIX_BRACKET_TYPE;
-    }
+  return ONIGERR_INVALID_POSIX_BRACKET_TYPE;
+}
 
 static int
 fetch_char_property_to_ctype(UChar** src, UChar* end, ParseEnv* env)

--- a/scintilla/oniguruma/src/regposix.c
+++ b/scintilla/oniguruma/src/regposix.c
@@ -223,7 +223,7 @@ onig_posix_regexec(onig_posix_regex_t* reg, const char* str, size_t nmatch,
   ENC_STRING_LEN(ONIG_C(reg)->enc, str, len);
   end = (UChar* )(str + len);
   r = onig_search(ONIG_C(reg), (UChar* )str, end, (UChar* )str, end,
-                    (OnigRegion* )pm, options);
+                  (OnigRegion* )pm, options);
 
   if (r >= 0) {
     r = 0; /* Match */

--- a/src/Edit.c
+++ b/src/Edit.c
@@ -5888,8 +5888,6 @@ static char* _GetReplaceString(HWND hwnd, CLPCEDITFINDREPLACE lpefr, int* iRepla
 static DocPos  _FindInTarget(LPCWSTR wchFind, int sFlags,
                              DocPos* begin, DocPos* end, bool bForceNext, FR_UPD_MODES fMode)
 {
-    UNREFERENCED_PARAMETER(bForceNext);
-
     static char chFind[8192] = { '\0' }; // max find buffer
 
     DocPos iPos = -1LL; // not found
@@ -6606,7 +6604,8 @@ static INT_PTR CALLBACK EditFindReplaceDlgProc(HWND hwnd, UINT umsg, WPARAM wPar
             DocPos end = Sci_GetDocEndPosition();
 
             LPCWSTR wchFind = _EditGetFindStrg(s_pEfrData->hwnd, s_pEfrData, false);
-            DocPos const  iPos = _FindInTarget(wchFind, (int)(s_pEfrData->fuFlags), &start, &end, false, FRMOD_NORM);
+            DocPos const iPos = _FindInTarget(wchFind, (int)(s_pEfrData->fuFlags), &start, &end, false, FRMOD_NORM);
+
             if (iPos >= 0) {
                 if (s_bIsReplaceDlg) {
                     SciCall_ScrollRange(end, iPos);
@@ -7077,7 +7076,7 @@ bool EditFindNext(HWND hwnd, const LPEDITFINDREPLACE lpefr, bool bExtendSelectio
 
     DocPos const iDocEndPos = Sci_GetDocEndPosition();
 
-    EditSetCaretToSelectionEnd(); // fluent swittch between Prev/Next
+    EditSetCaretToSelectionEnd(); // fluent switch between Prev/Next
     DocPos start = SciCall_GetCurrentPos();
     DocPos end = iDocEndPos;
 

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -1282,10 +1282,6 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
     ResetTmpCache();
     ResetIniFileCache();
 
-    UndoRedoReset();
-    SetSaveDone();
-
-
     // drag-n-drop into elevated process even does not work using:
     ///ChangeWindowMessageFilter(WM_DROPFILES, MSGFLT_ADD);
     ///ChangeWindowMessageFilter(WM_COPYDATA, MSGFLT_ADD);
@@ -11401,6 +11397,11 @@ bool FileLoad(const HPATHL hfile_pth, const FileLoadFlags fLoadFlags)
 
     if (fSuccess) {
 
+        if (!bReloadFile) {
+            UndoRedoReset();
+            SetSavePoint();
+        }
+
         Sci_GotoPosChooseCaret(0);
 
         if (!s_IsThisAnElevatedRelaunch) {
@@ -11454,6 +11455,7 @@ bool FileLoad(const HPATHL hfile_pth, const FileLoadFlags fLoadFlags)
         // consistent settings file handling (if loaded in editor)
         Flags.bSettingsFileSoftLocked = (Path_StrgComparePathNormalized(Paths.CurrentFile, Paths.IniFile) == 0);
 
+        ResetFileObservationData(true);
         InstallFileWatching(true);
 
         // the .LOG feature ...
@@ -11522,17 +11524,11 @@ bool FileLoad(const HPATHL hfile_pth, const FileLoadFlags fLoadFlags)
             Globals.fvCurFile.bTabsAsSpaces = (fioStatus.indentCount[I_TAB_LN] < fioStatus.indentCount[I_SPC_LN]) ? true : false;
             SciCall_SetUseTabs(!Globals.fvCurFile.bTabsAsSpaces);
         }
+
     }
     else if (!(Flags.bHugeFileLoadState || fioStatus.bUnknownExt)) {
         InfoBoxLng(MB_ICONWARNING, NULL, IDS_MUI_ERR_LOADFILE, Path_FindFileName(Paths.CurrentFile));
         Flags.bHugeFileLoadState = false; // reset
-    }
-
-    if (fSuccess) {
-        if (!bReloadFile) {
-            UndoRedoReset();
-        }
-        ResetFileObservationData(true);
     }
 
     UpdateToolbar();


### PR DESCRIPTION
 (in case of EOL or indent correction)
ref. issue #4630

RegExpr Search enhancements (ref. issue #4596)