### PR TITLE
Fix: Shift+Alt+Click on Hyperlink should not fire Hyperlink action

### DIFF
--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -8797,7 +8797,9 @@ static LRESULT _MsgNotifyFromEdit(HWND hwnd, const SCNotification* const scn)
 
     case SCN_INDICATORRELEASE: {
         if (SciCall_IndicatorValueAt(INDIC_NP3_HYPERLINK, scn->position) > 0) {
-            if ((_s_indic_click_modifiers & SCMOD_ALT) && SciCall_IsSelectionEmpty()) {
+            bool const bIsSel = Sci_IsMultiOrRectangleSelection() || !SciCall_IsSelectionEmpty();
+            if ((_s_indic_click_modifiers & SCMOD_ALT) && !bIsSel)
+            {
                 if (_s_indic_click_modifiers & SCMOD_CTRL) {
                     HandleHotSpotURLClicked(scn->position, OPEN_NEW_NOTEPAD3);
                 } else {

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -8797,8 +8797,8 @@ static LRESULT _MsgNotifyFromEdit(HWND hwnd, const SCNotification* const scn)
 
     case SCN_INDICATORRELEASE: {
         if (SciCall_IndicatorValueAt(INDIC_NP3_HYPERLINK, scn->position) > 0) {
-            bool const bIsSel = Sci_IsMultiOrRectangleSelection() || !SciCall_IsSelectionEmpty();
-            if ((_s_indic_click_modifiers & SCMOD_ALT) && !bIsSel)
+            bool const bIsNoSel = Sci_IsSingleSelection() && SciCall_IsSelectionEmpty();
+            if ((_s_indic_click_modifiers & SCMOD_ALT) && bIsNoSel)
             {
                 if (_s_indic_click_modifiers & SCMOD_CTRL) {
                     HandleHotSpotURLClicked(scn->position, OPEN_NEW_NOTEPAD3);

--- a/src/SciCall.h
+++ b/src/SciCall.h
@@ -759,6 +759,7 @@ DeclareSciCallR0(IsSelectionRectangle, SELECTIONISRECTANGLE, bool);
 
 #define Sci_IsThinSelection() (SciCall_GetSelectionMode() == SC_SEL_THIN)
 #define Sci_IsStreamSelection() (SciCall_GetSelectionMode() == SC_SEL_STREAM)
+#define Sci_IsSingleSelection() (SciCall_GetSelections() == 1)
 #define Sci_IsMultiSelection() ((SciCall_GetSelections() > 1) && !SciCall_IsSelectionRectangle())
 #define Sci_IsMultiOrRectangleSelection() ((SciCall_GetSelections() > 1) || SciCall_IsSelectionRectangle())
 


### PR DESCRIPTION
... if it is part of rectangular selection

ref. issue #4645