### PR TITLE
Fix horizontal mouse wheel scroll direction

### DIFF
--- a/scintilla/win32/ScintillaWin.cxx
+++ b/scintilla/win32/ScintillaWin.cxx
@@ -1647,7 +1647,8 @@ sptr_t ScintillaWin::MouseMessage(unsigned int iMessage, uptr_t wParam, sptr_t l
 
 			MouseWheelDelta &wheelDelta = (iMessage == WM_MOUSEHWHEEL) ? horizontalWheelDelta : verticalWheelDelta;
 			if (wheelDelta.Accumulate(wParam)) {
-				const int charsToScroll = charsPerScroll * wheelDelta.Actions();
+				const int scrollDirectionAdjustment  = (iMessage == WM_MOUSEHWHEEL) ? -1 : 1;
+				const int charsToScroll = charsPerScroll * wheelDelta.Actions() * scrollDirectionAdjustment;
 				const int widthToScroll = static_cast<int>(std::lround(charsToScroll * vs.aveCharWidth));
 				HorizontalScrollToClamped(xOffset + widthToScroll);
 			}


### PR DESCRIPTION
This change makes horizontal scrolling using touchpad gestures or mice with a scroll left/right feature match other Windows applications. The behavior prior to this commit is backwards when compared to the standard.

This change is intended to address issue https://github.com/rizonesoft/Notepad3/issues/5020