### PR TITLE
Change line selection on margin click from sub-line to whole-line

### DIFF
--- a/Build/Notepad3.ini
+++ b/Build/Notepad3.ini
@@ -39,6 +39,7 @@ SettingsVersion=5
 ;ShellAppUserModelID=Rizonesoft.Notepad3
 ;ShellUseSystemMRU=1
 ;StickyWindowPosition=0
+;SubWrappedLineSelectOnMarginClick=false
 ;LaunchInstanceWndPosOffset=28
 ;LaunchInstanceFullVisible=true
 ;UseOldStyleBraceMatching=0

--- a/src/Config/Config.cpp
+++ b/src/Config/Config.cpp
@@ -1335,6 +1335,8 @@ void LoadSettings()
 
     Settings2.NoCutLineOnEmptySelection = IniSectionGetBool(IniSecSettings2, L"NoCutLineOnEmptySelection", false);
 
+    Settings2.SubWrappedLineSelectOnMarginClick = IniSectionGetBool(IniSecSettings2, L"SubWrappedLineSelectOnMarginClick", false);
+
     Settings2.AnalyzeReliableConfidenceLevel = (float)clampi(IniSectionGetInt(IniSecSettings2, L"AnalyzeReliableConfidenceLevel", 90), 0, 100) / 100.0f;
 
     int const iAnsiCPBonusSet = clampi(IniSectionGetInt(IniSecSettings2, L"LocaleAnsiCodePageAnalysisBonus", 33), 0, 100);

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -2644,7 +2644,8 @@ static void  _InitializeSciEditCtrl(HWND hwndEditCtrl)
     SciCall_SetEdgeColumn(Settings.LongLinesLimit);
 
     // general margin
-    SciCall_SetMarginOptions(SC_MARGINOPTION_SUBLINESELECT);
+    SciCall_SetMarginOptions(SC_MARGINOPTION_NONE); // whole line select
+    //SciCall_SetMarginOptions(SC_MARGINOPTION_SUBLINESELECT);
 
     // Nonprinting characters
     SciCall_SetViewWS(Settings.ViewWhiteSpace ? SCWS_VISIBLEALWAYS : SCWS_INVISIBLE);

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -2644,8 +2644,7 @@ static void  _InitializeSciEditCtrl(HWND hwndEditCtrl)
     SciCall_SetEdgeColumn(Settings.LongLinesLimit);
 
     // general margin
-    SciCall_SetMarginOptions(SC_MARGINOPTION_NONE); // whole line select
-    //SciCall_SetMarginOptions(SC_MARGINOPTION_SUBLINESELECT);
+    SciCall_SetMarginOptions(Settings2.SubWrappedLineSelectOnMarginClick ? SC_MARGINOPTION_SUBLINESELECT : SC_MARGINOPTION_NONE);
 
     // Nonprinting characters
     SciCall_SetViewWS(Settings.ViewWhiteSpace ? SCWS_VISIBLEALWAYS : SCWS_INVISIBLE);

--- a/src/TypeDefs.h
+++ b/src/TypeDefs.h
@@ -764,6 +764,7 @@ typedef struct SETTINGS2_T {
     int     CurrentLineVerticalSlop;
     bool    NoCopyLineOnEmptySelection;
     bool    NoCutLineOnEmptySelection;
+    bool    SubWrappedLineSelectOnMarginClick;
     bool    LexerSQLNumberSignAsComment;
     int     ExitOnESCSkipLevel;
     int     ZoomTooltipTimeout;


### PR DESCRIPTION
option to get old behavior: `[Settings2] SubWrappedLineSelectOnMarginClick=true`

ref. issue #5024