### PR TITLE
several fixes

### DIFF
--- a/src/Dialogs.c
+++ b/src/Dialogs.c
@@ -4826,9 +4826,9 @@ void RestorePrevScreenPos(HWND hwnd)
 //
 //  DialogNewWindow()
 //
-void DialogNewWindow(HWND hwnd, bool bSaveOnRunTools, const HPATHL hFilePath, WININFO* wi)
+void DialogNewWindow(HWND hwnd, bool bSaveBeforeOpen, const HPATHL hFilePath, WININFO* wi)
 {
-    if (bSaveOnRunTools && !FileSave(FSF_Ask)) {
+    if (bSaveBeforeOpen && !FileSave(FSF_Ask)) {
         return;
     }
     WCHAR wch[80] = { L'\0' };

--- a/src/Dialogs.h
+++ b/src/Dialogs.h
@@ -77,7 +77,7 @@ WINDOWPLACEMENT WindowPlacementFromInfo(HWND hwnd, const WININFO* pWinInfo, SCRE
 void            SnapToWinInfoPos(HWND hwnd, const WININFO winInfo, SCREEN_MODE mode, UINT nCmdShow);
 void            RestorePrevScreenPos(HWND hwnd);
 
-void DialogNewWindow(HWND hwnd, bool bSaveOnRunTools, const HPATHL hFilePath, WININFO* wi);
+void DialogNewWindow(HWND hwnd, bool bSaveBeforeOpen, const HPATHL hFilePath, WININFO* wi);
 void DialogFileBrowse(HWND hwnd);
 void DialogGrepWin(HWND hwnd, LPCWSTR searchPattern);
 void DialogAdminExe(HWND hwnd,bool);

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -4765,7 +4765,7 @@ LRESULT MsgCommand(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
 
 
     case IDM_FILE_SAVE:
-        FileSave(FSF_SaveAlways);
+        FileSave(FSF_None);
         break;
 
 

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -9400,6 +9400,8 @@ void ParseCommandLine()
 
         while (bContinue && ExtractFirstArgument(lp3, lp1, lp2, (int)len)) {
             // options
+            size_t const lp3_len = StringCchLen(lp3, len);
+            bIsFileArg = bIsFileArg || (lp3[0] == L'"') && (lp3[lp3_len - 1] == L'"');
             if (!bIsFileArg && (lp1[0] == L'+') && (lp1[1] == L'\0')) {
                 Globals.CmdLnFlag_MultiFileArg = 2;
                 bIsFileArg = true;

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -3684,8 +3684,9 @@ static LRESULT _OnDropOneFile(HWND hwnd, HPATHL hFilePath, WININFO* wi)
     }
     else if (Path_IsExistingFile(hFilePath)) {
         //~ ignore Flags.bReuseWindow
+        bool const sameFile = (Path_StrgComparePath(hFilePath, Paths.CurrentFile, Paths.ModuleDirectory) == 0);
         if (IsKeyDown(VK_CONTROL) || wi) {
-            DialogNewWindow(hwnd, Settings.SaveBeforeRunningTools, hFilePath, wi);
+            DialogNewWindow(hwnd, sameFile, hFilePath, wi);
         } else {
             FileLoad(hFilePath, fLoadFlags, 0, 0);
         }
@@ -4840,7 +4841,7 @@ LRESULT MsgCommand(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
     case IDM_FILE_NEWWINDOW2: {
         SaveAllSettings(false);
         HPATHL hpth = (iLoWParam == IDM_FILE_NEWWINDOW2) ? Paths.CurrentFile : NULL;
-        DialogNewWindow(hwnd, Settings.SaveBeforeRunningTools, hpth, NULL);
+        DialogNewWindow(hwnd, (hpth != NULL), hpth, NULL);
     }
     break;
 
@@ -12117,7 +12118,7 @@ bool FileSave(FileSaveFlags fSaveFlags)
             LONG const answer = InfoBoxLng(typ, L"ReloadExSavedCfg", IDS_MUI_RELOADSETTINGS, tch);
             if (IsYesOkay(answer)) {
                 ///~SaveAllSettings(true); ~ already saved (CurrentFile)
-                DialogNewWindow(Globals.hwndMain, false, Paths.CurrentFile, NULL);
+                DialogNewWindow(Globals.hwndMain, true, Paths.CurrentFile, NULL);
                 CloseApplication();
             }
         }

--- a/test/test_files/StyleLexers/styleLexHTML/Design.html
+++ b/test/test_files/StyleLexers/styleLexHTML/Design.html
@@ -265,6 +265,16 @@
       does not follow platform conventions well. A second API could be implemented here that did
       follow platform conventions.
     </p>
+    
+    <?php
+	// Assign the value "Hello!" to the variable "greeting"
+	$greeting = "Hello!";
+	// Assign the value 8 to the variable "month"
+	$month = 8;
+	// Assign the value 2019 to the variable "year"
+	$year = 2019;
+	?>
+
   </body>
 </html>
 


### PR DESCRIPTION
+ chg: Ctrl+S does not forced saving doc any longer - only saves file, if save needed (doc changed)
   ref. issue #5178
   
+ chg: no need to save current file (doc changed) for open new (empty) np3 window

   ref. issue #5164

   

 +fix: accept file args with leading dash (needs quotes in any dash case)

    ref. issue #5160