### PR TITLE
FileChandedIndicator and FileDeletedIndicator may be 30 chars long

### DIFF
--- a/grepWinNP3/src/SearchDlg.cpp
+++ b/grepWinNP3/src/SearchDlg.cpp
@@ -66,6 +66,8 @@
 #include <numeric>
 #include <ranges>
 #include <string>
+#include <ctime>
+#include <chrono>
 #include <strsafe.h>
 
 #pragma warning(push)

--- a/src/Dialogs.c
+++ b/src/Dialogs.c
@@ -5359,10 +5359,10 @@ void SetWindowTitle(HWND hwnd, const HPATHL pthFilePath, const TITLEPROPS_T prop
     }
     if (properties.bFileChanged) {
         if (properties.bFileDeleted) {
-            StringCchCatN(szTitle, COUNTOF(szTitle), Settings2.FileDeletedIndicator, 3);
+            StringCchCatN(szTitle, COUNTOF(szTitle), Settings2.FileDeletedIndicator, COUNTOF(Settings2.FileDeletedIndicator));
         }
         else {
-            StringCchCatN(szTitle, COUNTOF(szTitle), Settings2.FileChangedIndicator, 3);
+            StringCchCatN(szTitle, COUNTOF(szTitle), Settings2.FileChangedIndicator, COUNTOF(Settings2.FileChangedIndicator));
         }
         StringCchCat(szTitle, COUNTOF(szTitle), L" ");
     }

--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -12664,9 +12664,9 @@ void SetNotifyIconTitle(HWND hwnd)
     } 
     if (IsFileChangedFlagSet()) {
         if (IsFileDeletedFlagSet()) {
-            StringCchCatN(nid.szTip, COUNTOF(nid.szTip), Settings2.FileDeletedIndicator, 3);
+            StringCchCatN(nid.szTip, COUNTOF(nid.szTip), Settings2.FileDeletedIndicator, COUNTOF(Settings2.FileDeletedIndicator));
         } else {
-            StringCchCatN(nid.szTip, COUNTOF(nid.szTip), Settings2.FileChangedIndicator, 3);
+            StringCchCatN(nid.szTip, COUNTOF(nid.szTip), Settings2.FileChangedIndicator, COUNTOF(Settings2.FileChangedIndicator));
         }
         StringCchCat(nid.szTip, COUNTOF(nid.szTip), L" ");
     }

--- a/src/TypeDefs.h
+++ b/src/TypeDefs.h
@@ -796,8 +796,8 @@ typedef struct SETTINGS2_T {
     HSTRINGW HyperlinkShellExURLCmdLnArgs;
     HSTRINGW FileDlgFilters;
 
-    WCHAR FileChangedIndicator[4];
-    WCHAR FileDeletedIndicator[4];
+    WCHAR FileChangedIndicator[31];
+    WCHAR FileDeletedIndicator[31];
 
     WCHAR DefaultExtension[MINI_BUFFER];
 


### PR DESCRIPTION
+chg: FileChandedIndicator and FileDeletedIndicator may be 30 chars long
+fix: vc143 compiler issue for grepWin

ref. issue #5325