### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/scintilla/oniguruma/src/regcomp.c
+++ b/scintilla/oniguruma/src/regcomp.c
@@ -1150,6 +1150,7 @@ compile_string_node(Node* node, regex_t* reg)
 
   for (; p < end; ) {
     len = enclen(enc, p);
+    if (p + len > end) len = end - p;
     if (len == prev_len) {
       slen++;
     }


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in compile_string_node() that was cloned from oniguruma but did not receive the security patch. The original issue was reported and fixed under http://git.php.net/?p=php-src.git;a=commit;h=c6e34d91b88638966662caac62c4d0e90538e317.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2019-9023
http://git.php.net/?p=php-src.git;a=commit;h=c6e34d91b88638966662caac62c4d0e90538e317
