### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/scintilla/oniguruma/src/regcomp.c
+++ b/scintilla/oniguruma/src/regcomp.c
@@ -6202,7 +6202,7 @@ concat_opt_exact_str(OptStr* to, UChar* s, UChar* end, OnigEncoding enc)
 
   for (i = to->len, p = s; p < end && i < OPT_EXACT_MAXLEN; ) {
     len = enclen(enc, p);
-    if (i + len > OPT_EXACT_MAXLEN) break;
+    if (i + len >= OPT_EXACT_MAXLEN) break;
     for (j = 0; j < len && p < end; j++) {
       /* coverity[overrun-local] */
       to->s[i++] = *p++;


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in concat_opt_exact_str() that was cloned from oniguruma but did not receive the security patch. The original issue was reported and fixed under https://github.com/kkos/oniguruma/commit/cbe9f8bd9cfc6c3c87a60fbae58fa1a85db59df0.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2020-26159
https://github.com/kkos/oniguruma/commit/cbe9f8bd9cfc6c3c87a60fbae58fa1a85db59df0
