### PR TITLE
Resolve regex library warnings

### DIFF
--- a/scintilla/scripts/FileGenerator.py
+++ b/scintilla/scripts/FileGenerator.py
@@ -181,5 +181,5 @@ def UpdateFileFromLines(path, lines, lineEndToUse):
 def ReplaceREInFile(path, match, replace, count=1):
     with codecs.open(path, "r", "utf-8") as f:
         contents = f.read()
-    contents = re.sub(match, replace, contents, count)
+    contents = re.sub(match, replace, contents, count=count)
     UpdateFile(path, contents)


### PR DESCRIPTION
## PR Summary
This small PR resolves the annoying regex library warnings showing starting Python3.11:
```python
/tmp/notepad3/scintilla/scripts/FileGenerator.py:184: DeprecationWarning: 'count' is passed as positional argument
```