### PR TITLE
Use Segment Heaps if available

### DIFF
--- a/minipath/res/MiniPath.exe.manifest
+++ b/minipath/res/MiniPath.exe.manifest
@@ -19,6 +19,7 @@
 			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
 			<ws2:longPathAware xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</ws2:longPathAware>
 			<gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">false</gdiScaling> <!-- if set true, no WM_DPICHANGED message is send -->
+			<heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
 		</asmv3:windowsSettings>
 	</asmv3:application>
 	<ms_compatibility:compatibility xmlns:ms_compatibility="urn:schemas-microsoft-com:compatibility.v1" xmlns="urn:schemas-microsoft-com:compatibility.v1">

--- a/res/Notepad3.exe.manifest
+++ b/res/Notepad3.exe.manifest
@@ -19,6 +19,7 @@
 			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
 			<ws2:longPathAware xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</ws2:longPathAware>
 			<gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">false</gdiScaling> <!-- if set true, no WM_DPICHANGED message is send -->
+			<heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
 		</asmv3:windowsSettings>
 	</asmv3:application>
 	<ms_compatibility:compatibility xmlns:ms_compatibility="urn:schemas-microsoft-com:compatibility.v1" xmlns="urn:schemas-microsoft-com:compatibility.v1">


### PR DESCRIPTION
Use Segment Heaps for memory (de)allocation if available via manifest opt-in. This applies to Win10 version 2004 and newer (such as Win11) otherwise falls back to the default NT Heaps. https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#heaptype


Testing shows that this reduces memory usage a little bit. attributes related to memory fragmentation have not been tested however Segment heaps are supposedly better in this regard as well.

[`!heap`](https://learn.microsoft.com/en-us/windows-hardware/drivers/debuggercmds/-heap) in WinDbg can be used to confirm that the memory heaps of the process(es) are indeed being allocated with the newer heap type.