### PR TITLE
enable Printer Driver Isolation

### DIFF
--- a/res/Notepad3.exe.manifest
+++ b/res/Notepad3.exe.manifest
@@ -15,6 +15,7 @@
     <!-- <msix xmlns="urn:schemas-microsoft-com:msix.v1" publisher="CN=Rizonesoft" packageName="RizonesoftNotepad3" applicationId="RizonesoftNotepad3"/> (issue #4949) -->
 	<asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" xmlns="urn:schemas-microsoft-com:asm.v3">
 		<asmv3:windowsSettings>
+			<printerDriverIsolation xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">true</printerDriverIsolation>
 			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
 			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
 			<ws2:longPathAware xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</ws2:longPathAware>


### PR DESCRIPTION
Makes it so that when interactions with printer drivers happen (such as if a user tries to print the text within a file) they will do so in a separate dedicated process (called `splwow64.exe`) so that they can't corrupt or crash the main Notepad3 process. 

https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#printerdriverisolation
https://peteronprogramming.wordpress.com/2018/01/22/application-level-printer-driver-isolation/


In my testing this seemed to work flawlessly. I also made sure to check if the `splwow64.exe` process was actually being created and used.