### PR TITLE
Update strings_it_it.rc

### DIFF
--- a/language/np3_it_it/strings_it_it.rc
+++ b/language/np3_it_it/strings_it_it.rc
@@ -73,7 +73,7 @@ BEGIN
     IDT_EDIT_REPLACE        "Sostituisci"
     IDT_VIEW_WORDWRAP       "A capo automatico"
     IDT_VIEW_ZOOMIN         "Zoom+"
-    IDT_VIEW_RESETZOOM      "Ripristina Zoom"
+    IDT_VIEW_RESETZOOM      "Ripristina zoom"
     IDT_VIEW_ZOOMOUT        "Zoom-"
     IDT_VIEW_SCHEME         "Seleziona schema"
     IDT_VIEW_SCHEMECONFIG   "Personalizza schemi"
@@ -143,16 +143,16 @@ BEGIN
     IDS_MUI_ERR_UNICODE     "Errore nella conversione di questo file Unicode\nSe salvi il file si verificherà una perdita di dati!"
     IDS_MUI_ERR_BITMAP      "Dimensione bitmap non adeguata '%s'\nDimensione corretta: %i x %i (larghezza >= %i x altezza)"
     IDS_MUI_ERR_ELEVATED_RIGHTS
-                            "Errore elevazione dei diritti utente!"
+                            "Errore elevazione diritti utente!"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_MUI_ERR_UNICODE2    "Alcuni set di caratteri nel testo attuale non sono supportati dalla codifica selezionata, e potrebbero essere al salvataggio rimpiazzati da segnaposto predefiniti. È opportuno selezionare una codifica differente. Vuoi continuare?"
+    IDS_MUI_ERR_UNICODE2    "Alcuni set caratteri nel testo attuale non sono supportati dalla codifica selezionata, e potrebbero essere sostituiti nel salvataggio da segnaposto predefiniti. È opportuno selezionare una codifica differente. Vuoi continuare?"
     IDS_MUI_ERR_DROP        "Con una unica operazione può essere rilasciato solo un file!"
     IDS_MUI_ERR_ACCESSDENIED
                             "Il file '%s' non può essere salvato e potrebbe essere protetto\n\nVuoi aprire '%s' con diritti amministrativi?"
-    IDS_MUI_ERR_ADMINEXE    "Nessun eseguibile amministrativo trovato\nVuoi controllare https://rizonesoft.com?"
+    IDS_MUI_ERR_ADMINEXE    "Nessun eseguibile amministrativo trovato.\nVuoi controllare https://rizonesoft.com?"
     IDS_MUI_WARN_LOAD_BIG_FILE
                             "Vuoi aprire questo file grande?\n\t(dimensione: %s >= %s)!\n(non saranno applicate le evidenziazioni di stile e sintassi !)"
     IDS_MUI_ERR_FILE_TOO_LARGE
@@ -171,48 +171,48 @@ STRINGTABLE
 BEGIN
     IDS_MUI_SELRECT         "Questa operazione non può essere eseguita in una selezione rettangolare"
     IDS_MUI_SELMULTI        "Questa operazione non può essere eseguita in una multi-selezione"
-    IDS_MUI_SELRECTORMULTI  "Questa operazione non può essere eseguita in una selezione rettangolare o in una multi-selezione"
+    IDS_MUI_SELRECTORMULTI  "Questa operazione non può essere eseguita in una selezione rettangolare o in una multi selezione"
     IDS_MUI_BUFFERTOOSMALL  "Questa operazione non può essere eseguita (linee troppo lunghe)"
-    IDS_MUI_FIND_WRAPFW     "Raggiunta la fine del documento, la ricerca riprende dall'inizio"
-    IDS_MUI_FIND_WRAPRE     "Raggiunto l'inizio del documento, la ricerca riprende dalla fine"
+    IDS_MUI_FIND_WRAPFW     "Raggiunta la fine del documento, la ricerca riprenderà dall'inizio"
+    IDS_MUI_FIND_WRAPRE     "Raggiunto l'inizio del documento, la ricerca riprenderà dalla fine"
     IDS_MUI_NOTFOUND        "Nessuna corrispondenza trovata per il pattern di ricerca specificato"
     IDS_MUI_REPLCOUNT       "%s occorrenze del pattern di ricerca specificato sono state sostituite"
-    IDS_MUI_ASK_ENCODING    "Cambiare la codifica del file potrebbe sostituire testo non supportato con un carattere di default, e la cronologia delle modifiche (annulla modifiche) sarà svuotata. Vuoi continuare?"
-    IDS_MUI_ASK_ENCODING2   "Stai per cambiare la codifica di un file vuoto. Questo cancellerà la cronologia delle modifiche (annulla modifiche), perché non può essere sincronizzata con la nuova codifica. Vuoi continuare?"
-    IDS_MUI_ASK_CLEAR_UNDO  "Questa operazione cancella la cronologia delle modifiche. Continuare?"
-    IDS_MUI_READONLY_SAVE   "'%s' è in sola lettura. Salvare in un file differente?"
+    IDS_MUI_ASK_ENCODING    "Cambiare la codifica del file potrebbe sostituire testo non supportato con un carattere predefinito, e la cronologia modifiche (annulla modifiche) sarà svuotata. Vuoi continuare?"
+    IDS_MUI_ASK_ENCODING2   "Stai per cambiare la codifica di un file vuoto. Questo cancellerà la cronologia modifiche (annulla modifiche), perché non può essere sincronizzata con la nuova codifica. Vuoi continuare?"
+    IDS_MUI_ASK_CLEAR_UNDO  "Questa operazione cancellerà la cronologia modifiche. Continuare?"
+    IDS_MUI_READONLY_SAVE   "'%s' è in sola lettura. Vuoi salvare in un file differente?"
     IDS_MUI_FILECHANGENOTIFY
-                            "Il file corrente è stato modificato da un programma esterno\nScegliere:\n\nIgnore -\t\tIgnora ulteriori modifiche\nRicarica -\t\tRicarica File\nMonitor -\t\tPassa al monitoraggio del file"
-    IDS_MUI_FILECHANGENOTIFY2 "Il file corrente è stato cancellato. Salvarlo adesso?"
+                            "Il file attuale è stato modificato da un programma esterno\nScegliere:\n\nIgnore -\t\tIgnora ulteriori modifiche\nRicarica -\t\tRicarica File\nMonitor -\t\tPassa al monitoraggio del file"
+    IDS_MUI_FILECHANGENOTIFY2 "Il file attuale è stato cancellato. Vuoi salvarlo?"
     IDS_MUI_FILELOCK_ERROR  "Impossibile ottenere il blocco esclusivo per '%s'!"
     IDS_MUI_STICKYWINPOS    "La posizione della finestra 'sticky' è abilitata. Qualunque finestra Notepad3 userà le attuali impostazioni di posizione finestra"
-    IDS_MUI_SAVEDSETTINGS   "Le impostazioni correnti di Notepad3 sono state salvate"
-    IDS_MUI_CREATEINI_FAIL  "Errore nella creazione del file delle impostazioni"
-    IDS_MUI_WRITEINI_FAIL   "Errore nella scrittura del file delle impostazioni"
+    IDS_MUI_SAVEDSETTINGS   "Le impostazioni attuali di Notepad3 sono state salvate"
+    IDS_MUI_CREATEINI_FAIL  "Errore nella creazione del file impostazioni"
+    IDS_MUI_WRITEINI_FAIL   "Errore nella scrittura del file impostazioni"
     IDS_MUI_INIFILE_READONLY
                             "Il file di configurazione è in sola lettura - Vuoi ignorare e sovrascrivere le impostazioni?"
     IDS_MUI_SETTINGSNOTSAVED
-                            "Non è stato trovato un file delle impostazioni\nPer conservare le modifiche agli stili, salva le impostazioni adesso (F7) oppure ritorna alla configurazione degli Schemi (Ctrl+F12) ed esporta gli stili"
+                            "Non è stato trovato un file delle impostazioni\nPer conservare le modifiche agli stili, salva le impostazioni (F7) o ritorna alla configurazione degli schemi (Ctrl+F12) ed esporta gli stili"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_MUI_RELOADSETTINGS     "Attivare le impostazioni salvate riavviando l'applicazione?\n\n%s"
-    IDS_MUI_RELOADCFGSEX       "Continuando senza riavviare, le impostazioni salvate non sono applicate e saranno sovrascritte dalle impostazioni interne all'uscita del programma!"
-    IDS_MUI_EXPORT_FAIL        "Errore nell'esportazione degli Stili su '%s'"
+    IDS_MUI_RELOADSETTINGS     "Vuoi attivare le impostazioni salvate riavviando l'applicazione?\n\n%s"
+    IDS_MUI_RELOADCFGSEX       "Continuando senza riavviare, le impostazioni salvate non saranno applicate e saranno sovrascritte dalle impostazioni interne all'uscita del programma!"
+    IDS_MUI_EXPORT_FAIL        "Errore nell'esportazione degli stili in '%s'"
     IDS_MUI_REGEX_INVALID      "Errore nella valutazione dell'espressione regolare. La RegExp non è valida!"
-    IDS_MUI_DROP_NO_FILE       "Nessun nome file valido\nSe stai facendo drag-n-drop da una applicazione 32-bit,\nrilascia il file nella barra strumenti di Notepad3"
-    IDS_MUI_DROP_CAP_EXCEEDED  "Sono stati rilasciati più file rispetto al limite configurato (%i). Se necessario aumentare Settings2.MaxFileDropInstances."
+    IDS_MUI_DROP_NO_FILE       "Nessun nome file valido.\nSe stai facendo drag-n-drop da una applicazione 32-bit,\nrilascia il file nella barra strumenti di Notepad3"
+    IDS_MUI_DROP_CAP_EXCEEDED  "Sono stati rilasciati più file rispetto al limite configurato (%i). Se necessario aumenta Settings2.MaxFileDropInstances."
     IDS_MUI_URL_DIR_EXISTS     "La cartella specificata nella URL esiste!"
     IDS_MUI_URL_FILE_EXISTS    "Il file specificato nella URL esiste!"
     IDS_MUI_URL_PATH_NOT_FOUND 
                                "Il percorso specificato nella URL non è stato trovato!"
-    IDS_MUI_URL_OPEN_FILE      "\nAlt + Click per aprire il file"
-    IDS_MUI_URL_OPEN_BROWSER   "\nCtrl + Click per aprire il link nel browser"
+    IDS_MUI_URL_OPEN_FILE      "\nAlt + Clic per aprire il file"
+    IDS_MUI_URL_OPEN_BROWSER   "\nCtrl + Clic per aprire il collegamento nel browser"
     IDS_MUI_UNMATCHED_BRACE    "Mancata corrispondenza parentesi graffe"
     IDS_MUI_NO_ENCLOSING_BRACE "Manca parentesi graffa di chiusura"
     IDS_MUI_INF_PRSVFILEMODTM  
-                               "Conservazione della data di ultima modifica originale abilitata\nQuesta opzione rimarrà attiva per questa sessione!"
+                               "Conservazione data ultima modifica originale abilitata\nQuesta opzione rimarrà attiva per questa sessione!"
     IDS_MUI_OUT_OFF_OCCMRK     "Marcatori occorrenza in esaurimento (Segnalibro/evidenziatura)!"
     IDS_MUI_DOCUMENT_READONLY  
                                "Il documento è bloccato per la sola visualizzazione. Vuoi mantenere il blocco per prevenire le modifiche?"
@@ -220,46 +220,46 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_MUI_ASK_SAVE        "Salvare le modifiche a:\n%s?"
-    IDS_MUI_ASK_REVERT      "Ripristinare il file all'ultimo salvataggio effettuato?"
+    IDS_MUI_ASK_SAVE        "Vuoi salvare le modifiche a:\n%s?"
+    IDS_MUI_ASK_REVERT      "Vuoi ripristinare il file all'ultimo salvataggio effettuato?"
     IDS_MUI_ASK_RECODE      "La ricodifica richiede di ricaricare il file dal disco: eventuali modifiche non salvate saranno perse!"
     IDS_MUI_ASK_CREATE      "'%s' non trovato\nVuoi creare questo file?"
-    IDS_MUI_PRINT_HEADER    "Nome file, data e ora attuali|Nome file, Data attuale|Nome file|Lascia vuoto"
-    IDS_MUI_PRINT_FOOTER    "Numero di pagina|Lascia vuoto"
+    IDS_MUI_PRINT_HEADER    "Nome file, data e ora attuali|Nome file, data attuale|Nome file|Lascia vuoto"
+    IDS_MUI_PRINT_FOOTER    "Numero pagina|Lascia vuoto"
     IDS_MUI_PRINT_COLOR     "Normale|Inverti (sfondo scuro)|Nero su bianco|Colore su bianco|Colore su bianco (tranne i numeri di linea)|Colori a schermo"
     IDS_MUI_PRINT_PAGENUM   "Pagina %i"
     IDS_MUI_WARN_STYLE_RESET
-                            "Questa azione ripristina le impostazioni di fabbrica della modalità colore desiderata, e attiverà il file .ini della configurazione standard!"
+                            "Questa azione ripristinerà le impostazioni predefinite della modalità colore desiderata, e attiverà il file .ini della configurazione standard!"
     IDS_MUI_ASK_INSTANCE_EXISTS
-                            "Modalità istanza singola:\n\nImpostare il focus sull'istanza del file già caricata?"
+                            "Modalità istanza singola:\n\nImposta il focus sull'istanza del file già caricata?"
 END
 
 STRINGTABLE
 BEGIN
     IDS_MUI_PRINT_EMPTY     "Questo documento non contiene alcun testo da stampare"
     IDS_MUI_PRINT_ERROR     "Errore nella stampa di '%s'!"
-    IDS_MUI_FAV_SUCCESS     "Un collegamento al file corrente è stato creato nella cartella Preferiti"
-    IDS_MUI_FAV_FAILURE     "Impossibile creare un collegamento al file corrente\nControlla che non ci sia già un file con lo stesso nome"
+    IDS_MUI_FAV_SUCCESS     "È stato creato un collegamento al file attuale nella cartella Preferiti"
+    IDS_MUI_FAV_FAILURE     "Impossibile creare un collegamento al file attuale\nControlla che non ci sia già un file con lo stesso nome"
     IDS_MUI_READONLY_MODIFY "Impossibile modificare gli attributi di '%s'"
     IDS_MUI_SAVEPOS         "&Salva posizione\tCtrl+S"
     IDS_MUI_RESETPOS        "&Ripristina posizione\tCtrl+R"
     IDS_MUI_PREVIEW         "&Anteprima impostazioni\tCtrl+P"
-    IDS_MUI_PASS_FAILURE    "La frase d'accesso è sbagliata\nRiprovre con una frase d'accesso diversa?"
-    IDS_MUI_NOPASS          "Decrittazione annullata!\nLeggere i dati grezzi criptati?"
-    IDS_MUI_STY_BASESTD     "BASE (Stile di Default):"
-    IDS_MUI_STY_BASE2ND     "BASE (2° Stile di Default):"
-    IDS_MUI_STY_LEXDEF      "%s - Stile di Default:"
+    IDS_MUI_PASS_FAILURE    "La password d'accesso è eerrata\nVuoi riprovare con una password diversa?"
+    IDS_MUI_NOPASS          "Decrittazione annullata!\nVuoi leggere i dati grezzi criptati?"
+    IDS_MUI_STY_BASESTD     "BASE (stile predefinito):"
+    IDS_MUI_STY_BASE2ND     "BASE (2° stile predefinito):"
+    IDS_MUI_STY_LEXDEF      "%s - stile predefinito:"
     IDS_MUI_STY_LEXSTYLE    "Stile di %s:"
     IDS_MUI_TITLE_RELBASE   "+++ BASE (%s) +++"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_MUI_TRANSL_AUTHOR   "(it-IT) Traduzione italiana di Matteo-Nigro"
+    IDS_MUI_TRANSL_AUTHOR   "(it-IT) Traduzione italiana di Matteo-Nigro e R.B."
     IDS_MUI_TITLE_FIXBASE   "BASE (%s)"
     IDS_MUI_TITLE_RELCUR    "+++ %s: Stile %s +++"
-    IDS_MUI_TITLE_FIXCUR    "%s: Stile %s"
-    IDS_MUI_TITLE_RELARB    "+++ Stile '%s' (%s) +++"
+    IDS_MUI_TITLE_FIXCUR    "%s: atile %s"
+    IDS_MUI_TITLE_RELARB    "+++ atile '%s' (%s) +++"
     IDS_MUI_TITLE_FIXARB    "Stile '%s' (%s)"
     IDS_MUI_ASSOCIATED_EXT  "Estensioni associate:"
     IDS_MUI_ZERO_LEN_MATCH  "^ corrispondenza lunghezza 0"
@@ -270,22 +270,22 @@ END
 STRINGTABLE
 BEGIN
     IDS_MUI_MENU_LANGUAGE   "&Lingua"
-    IDS_USE_LOCALE_DATEFMT  "La lingua definisce il Formato &Data"
-    IDS_MUI_MENU_THEMES     "&Collezione di Schemi"
-    IDM_THEMES_FACTORY_RESET "Ripristino &fabbrica"
+    IDS_USE_LOCALE_DATEFMT  "La lingua definisce il Formato &data"
+    IDS_MUI_MENU_THEMES     "&Collezione schemi"
+    IDM_THEMES_FACTORY_RESET "Ripristino &predefiniti"
     IDM_THEMES_STD_CFG       "Configurazione &standard"
     IDS_MUI_STATUSBAR_PREFIXES "Ln  ,Col  ,Sel  ,Sb  ,SLn  ,Occ  ,,,,,,,Car  ,Sost  ,Ris  ,U+,"
     IDS_MUI_STATUSBAR_POSTFIXES ",,,,,,,,,,,,,,,,"
     IDS_CLEAR_ALL           "Pulisci tutto"
     IDS_MUI_CLEAR_FIND_HISTORY
-                            "Pulisci Cronologia Ricerche"
+                            "Azzera cronologia ricerche"
     IDS_MUI_CLEAR_REPL_HISTORY
-                            "Pulisci Cronologia Sostituzioni"
+                            "Azzera cronologia sostituzioni"
     IDS_MUI_SEARCHCLIPIFEMPTY
-                            "Ricerca negli Appunti se la selezione è vuota"
-    IDS_MUI_REPLCLIPTAG     "Sostituisci con gli Appunti con la scorciatoia [^c]"
-    IDS_MUI_WRAPSEARCH_FWD  "Corrispondenza Wrap-Around dall'inizio"
-    IDS_MUI_WRAPSEARCH_BCK  "Corrispondenza Wrap-Around dalla fine"
+                            "Se la selezione è vuota cerca negli appunti "
+    IDS_MUI_REPLCLIPTAG     "Sostituisci gli Appunti con la scorciatoia [^c]"
+    IDS_MUI_WRAPSEARCH_FWD  "Corrispondenza a capo aitomatico dall'inizio"
+    IDS_MUI_WRAPSEARCH_BCK  "Corrispondenza a capo automatico dalla fine"
 END
 
 STRINGTABLE
@@ -370,7 +370,7 @@ IDS_MUI_ABOUT_RTF_1  "\
 \\cf0 \\fs20\\b1\\ul1 Collaboratori:\\ul0\\b0\\fs18\\par\
 "
 IDS_MUI_ABOUT_RTF_2  "\
-\\cf0 \\fs20\\b1\\ul1 Open Source / Librerie:\\ul0\\b0\\fs18\\par\
+\\cf0 \\fs20\\b1\\ul1 Open Source / librerie:\\ul0\\b0\\fs18\\par\
 "
 IDS_MUI_ABOUT_RTF_3  "\
 \\cf0 \\fs20\\b1\\ul1 Riconoscimenti:\\ul0\\b0\\fs18\\par\

--- a/language/np3_it_it/strings_it_it.rc
+++ b/language/np3_it_it/strings_it_it.rc
@@ -190,32 +190,32 @@ BEGIN
     IDS_MUI_CREATEINI_FAIL  "Errore nella creazione del file delle impostazioni"
     IDS_MUI_WRITEINI_FAIL   "Errore nella scrittura del file delle impostazioni"
     IDS_MUI_INIFILE_READONLY
-                            "Il file di configurazione è in Sola Lettura - Ignorare e sovrascrivere le impostazioni?"
+                            "Il file di configurazione è in sola lettura - Vuoi ignorare e sovrascrivere le impostazioni?"
     IDS_MUI_SETTINGSNOTSAVED
                             "Non è stato trovato un file delle impostazioni\nPer conservare le modifiche agli stili, salva le impostazioni adesso (F7) oppure ritorna alla configurazione degli Schemi (Ctrl+F12) ed esporta gli stili"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_MUI_RELOADSETTINGS   "Attivare le impostazioni salvate riavviando l'applicazione?\n\n%s"
-    IDS_MUI_RELOADCFGSEX     "Continuando senza riavviare, le impostazioni salvate non sono applicate e saranno sovrascritte dalle impostazioni interne all'uscita del programma!"
-    IDS_MUI_EXPORT_FAIL      "Errore nell'esportazione degli Stili su '%s'"
-    IDS_MUI_REGEX_INVALID    "Errore nella valutazione dell'espressione regolare. La RegExp non è valida!"
-    IDS_MUI_DROP_NO_FILE     "Nessun nome file valido\nSe stai facendo drag-n-drop da una applicazione 32-bit,\nrilascia il file nella barra strumenti di Notepad3"
-    IDS_MUI_DROP_CAP_EXCEEDED "Dropped more files than the configured limit (%i). Increase Settings2.MaxFileDropInstances if needed."
-    IDS_MUI_URL_DIR_EXISTS   "La cartella specificata nella URL esiste!"
-    IDS_MUI_URL_FILE_EXISTS  "Il file specificato nella URL esiste!"
-    IDS_MUI_URL_PATH_NOT_FOUND
-                             "Il percorso specificato nella URL non è stato trovato!"
-    IDS_MUI_URL_OPEN_FILE    "\nAlt + Click per aprire il file"
-    IDS_MUI_URL_OPEN_BROWSER "\nCtrl + Click per aprire il link nel browser"
-    IDS_MUI_UNMATCHED_BRACE  "Mancata corrispondenza parentesi graffe"
+    IDS_MUI_RELOADSETTINGS     "Attivare le impostazioni salvate riavviando l'applicazione?\n\n%s"
+    IDS_MUI_RELOADCFGSEX       "Continuando senza riavviare, le impostazioni salvate non sono applicate e saranno sovrascritte dalle impostazioni interne all'uscita del programma!"
+    IDS_MUI_EXPORT_FAIL        "Errore nell'esportazione degli Stili su '%s'"
+    IDS_MUI_REGEX_INVALID      "Errore nella valutazione dell'espressione regolare. La RegExp non è valida!"
+    IDS_MUI_DROP_NO_FILE       "Nessun nome file valido\nSe stai facendo drag-n-drop da una applicazione 32-bit,\nrilascia il file nella barra strumenti di Notepad3"
+    IDS_MUI_DROP_CAP_EXCEEDED  "Sono stati rilasciati più file rispetto al limite configurato (%i). Se necessario aumentare Settings2.MaxFileDropInstances."
+    IDS_MUI_URL_DIR_EXISTS     "La cartella specificata nella URL esiste!"
+    IDS_MUI_URL_FILE_EXISTS    "Il file specificato nella URL esiste!"
+    IDS_MUI_URL_PATH_NOT_FOUND 
+                               "Il percorso specificato nella URL non è stato trovato!"
+    IDS_MUI_URL_OPEN_FILE      "\nAlt + Click per aprire il file"
+    IDS_MUI_URL_OPEN_BROWSER   "\nCtrl + Click per aprire il link nel browser"
+    IDS_MUI_UNMATCHED_BRACE    "Mancata corrispondenza parentesi graffe"
     IDS_MUI_NO_ENCLOSING_BRACE "Manca parentesi graffa di chiusura"
-    IDS_MUI_INF_PRSVFILEMODTM
-                             "Conservazione della data di ultima modifica originale abilitata\nQuesta opzione rimarrà attiva per questa sessione!"
-    IDS_MUI_OUT_OFF_OCCMRK   "Marcatori occorrenza in esaurimento (Segnalibro/evidenziatura)!"
-    IDS_MUI_DOCUMENT_READONLY
-                             "Il documento è bloccato per la sola visualizzazione. Vuoi mantenere il blocco per prevenire le modifiche?"
+    IDS_MUI_INF_PRSVFILEMODTM  
+                               "Conservazione della data di ultima modifica originale abilitata\nQuesta opzione rimarrà attiva per questa sessione!"
+    IDS_MUI_OUT_OFF_OCCMRK     "Marcatori occorrenza in esaurimento (Segnalibro/evidenziatura)!"
+    IDS_MUI_DOCUMENT_READONLY  
+                               "Il documento è bloccato per la sola visualizzazione. Vuoi mantenere il blocco per prevenire le modifiche?"
 END
 
 STRINGTABLE


### PR DESCRIPTION
@rizonesoft 

Pelase merge. Thanks.

Note: please check strange wrap/newline about some strings with key name and key value not on same line

```
    IDS_MUI_INIFILE_READONLY
                            "Configuration file is readonly - ignore and override settings?"
    IDS_MUI_SETTINGSNOTSAVED
                            "No existing configuration file was found\nTo keep your style modifications, save settings now (F7) or go back to scheme configuration (Ctrl+F12) and export your styles"
    IDS_MUI_URL_PATH_NOT_FOUND
                             "URL specified path not found!"
    IDS_MUI_INF_PRSVFILEMODTM
                             "Preserving original File Modification Timestamp enabled\nThis option will stay for this session!"
    IDS_MUI_DOCUMENT_READONLY
                             "The document is locked for view only. Keep the lock to prevent editing?"
```
As you can KEY name an string value are not oin same line

Should be like

```
    IDS_MUI_INIFILE_READONLY "Configuration file is readonly - ignore and override settings?"
    IDS_MUI_SETTINGSNOTSAVED "No existing configuration file was found\nTo keep your style modifications, save settings now (F7) or go back to scheme configuration (Ctrl+F12) and export your styles"
    IDS_MUI_URL_PATH_NOT_FOUND "URL specified path not found!"
    IDS_MUI_INF_PRSVFILEMODTM "Preserving original File Modification Timestamp enabled\nThis option will stay for this session!"
    IDS_MUI_DOCUMENT_READONLY "The document is locked for view only. Keep the lock to prevent editing?"
```

Thanks.
