### PR TITLE
Fix typo in MarkOccurrencesMaxCount description

### DIFF
--- a/Build/Docs/Notepad3.txt
+++ b/Build/Docs/Notepad3.txt
@@ -155,7 +155,7 @@ Specifies Scintilla's internal rendering technology and font quality.
     3: SC_EFF_QUALITY_LCD_OPTIMIZED
 
 MarkOccurrencesMaxCount
-The maximum number of counts for marking occurences, if this option is active.
+The maximum number of counts for marking occurrences, if this option is active.
 The default is 2000.
 
 UseOldStyleBraceMatching


### PR DESCRIPTION
Typo in the settings documentation: `occurences` -> `occurrences`.

`Build/Docs/Notepad3.txt:158`, in the description of `MarkOccurrencesMaxCount`. The setting name itself and the two other mentions in the same file already use the correct spelling.
