### PR TITLE
Set activeCodePage to UTF-8 in the Notepad3.exe.manifest file.

### DIFF
--- a/res/Notepad3.exe.manifest
+++ b/res/Notepad3.exe.manifest
@@ -21,6 +21,7 @@
 			<ws2:longPathAware xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</ws2:longPathAware>
 			<gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">false</gdiScaling> <!-- if set true, no WM_DPICHANGED message is send -->
 			<heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
+			<activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
 		</asmv3:windowsSettings>
 	</asmv3:application>
 	<ms_compatibility:compatibility xmlns:ms_compatibility="urn:schemas-microsoft-com:compatibility.v1" xmlns="urn:schemas-microsoft-com:compatibility.v1">


### PR DESCRIPTION
Fix #5963 

<s>Referring to [zufuliu#168](https://github.com/zufuliu/notepad4/issues/168), sometimes StrTrimA() cannot handle some UTF-8 strings correctly, so I changed the code to directly check the last two chars.</s>

I have found another way to solve this issue without touching code, referring to [Use UTF-8 code pages in Windows apps](https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page), so that ANSI APIs can also handle UTF-8 strings correctly.