### PR TITLE
fix: Split undo transactions before line breaks, rather than after them

### DIFF
--- a/src/Notepad3.c
+++ b/src/Notepad3.c
@@ -9742,6 +9742,11 @@ inline static LRESULT _MsgNotifyLean(const SCNotification* const scn, bool* bMod
         bool const bInUndoRedoStep = (iModType & (SC_PERFORMED_UNDO | SC_PERFORMED_REDO));
         if (iModType & SC_MOD_INSERTCHECK) {
             if (!bInUndoRedoStep) {
+                if (Settings.SplitUndoTypingSeqOnLnBreak && (scn->length > 0) && ((scn->text[0] == '\r') || (scn->text[0] == '\n'))) {
+                    // split the undo transaction BEFORE the line break, so the next transaction
+                    // will include both the line break and subsequent auto indentation.
+                    _SplitUndoTransaction();
+                }
                 _HandleInsertCheck(scn);
             }
         }
@@ -9848,11 +9853,6 @@ static LRESULT _MsgNotifyFromEdit(HWND hwnd, const SCNotification* const scn)
             int const iModType = scn->modificationType;
             if (scn->linesAdded != 0) {
                 EditBookmarkAdjustNavigation(SciCall_LineFromPosition(scn->position), scn->linesAdded);
-                if (Settings.SplitUndoTypingSeqOnLnBreak && (scn->linesAdded > 0)) {
-                    if (!(iModType & (SC_PERFORMED_UNDO | SC_PERFORMED_REDO))) {
-                        _SplitUndoTransaction();
-                    }
-                }
             }
             if (s_bInMultiEditMode && !(iModType & SC_MULTILINEUNDOREDO)) {
                 if (!Sci_IsMultiSelection()) {


### PR DESCRIPTION
Previously, an undo transaction was started after a line break, so the line break itself was in the end of the previous transaction, and a subsequent auto indention that was triggered by the line break started a new transaction. Pressing Ctrl+Z undid the auto indention, and pressing Ctrl+Z a second time undid the line break with previous inputs.

In order to be consistent with other editors, a new undo transaction should start after the line break, so they are in the same transaction.


---

### Steps to reproduce

1. Open empty document.
2. Turn 'auto indention' and 'split undo transaction at line breaks' on.
3. Type `  aa` (space space A A).
4. Press Enter. This moves the cursor to the next line and audo-indent it by two spaces.
5. Press Ctrl+Z. This undoes the auto indention, but does not undo the line break.
6. Press Ctrl+Z again, this undoes `  aa` with the line break.

### Expected behavior

Like in Visual Studio, step 5 should undo the auto indention and the line break, and step 6 should undo `  aa` (since there's no longer a line break to undo).
